### PR TITLE
Stop horizontal scroll bar appearing, apply min 200px responsive width

### DIFF
--- a/src/LeagueStyleElements.elm
+++ b/src/LeagueStyleElements.elm
@@ -5,7 +5,7 @@ import Style exposing (..)
 import Style.Border as Border
 import Style.Color as Color
 import Style.Font as Font
-import Pages.Progressive exposing (FontSize)
+import Pages.Responsive exposing (FontSize)
 
 -- I didn't really want to use this, but I couldn't get a type definition to work without it
 -- I should have documented which one this was, so I can do further investigation, or to 

--- a/src/Pages/LeagueList/View.elm
+++ b/src/Pages/LeagueList/View.elm
@@ -8,41 +8,41 @@ import Element.Events exposing (onClick)
 import LeagueStyleElements exposing (..)
 import Msg exposing (..)
 import Models.LeagueSummary exposing (LeagueSummary)
-import Pages.Progressive exposing (..)
+import Pages.Responsive exposing (..)
 import Pages.MaybeResponse exposing (..)
 import Pages.Page exposing (..)
 import Pages.HeaderBar exposing ( .. ) 
 import Pages.HeaderBarItem exposing (..)
 
 
-page : WebData (List LeagueSummary) -> Progressive -> Page
-page response progressive =
+page : WebData (List LeagueSummary) -> Responsive -> Page
+page response responsive =
     Page
         ( SingleHeader <| 
             HeaderBar 
                 [ HeaderButtonSizedSpace ] 
                 "Leagues" 
                 [ RefreshHeaderButton AllSheetSummaryRequest ] )
-        ( maybeResponse response <| leagueList progressive )
+        ( maybeResponse response <| leagueList responsive )
 
-leagueList: Progressive -> List LeagueSummary -> Element Styles variation Msg
-leagueList progressive leagueSummaries =
+leagueList: Responsive -> List LeagueSummary -> Element Styles variation Msg
+leagueList responsive leagueSummaries =
     column 
         None 
         [ 
             width (percent 100)
             , class "data-test-leagues"   
         ] 
-        (List.map (leagueTitle progressive) leagueSummaries)
+        (List.map (leagueTitle responsive) leagueSummaries)
 
-leagueTitle : Progressive -> LeagueSummary -> Element Styles variation Msg
-leagueTitle progressive league =
+leagueTitle : Responsive -> LeagueSummary -> Element Styles variation Msg
+leagueTitle responsive league =
     el 
         LeagueListLeagueTitle 
         [ 
-            padding progressive.mediumGap
-            , spacing progressive.smallGap
-            , width (percent progressive.percentageWidthToUse)
+            padding responsive.mediumGap
+            , spacing responsive.smallGap
+            , width (percent responsive.percentageWidthToUse)
             , class "data-test-league"
             , center
             , onClick <| IndividualSheetRequest league.title

--- a/src/Pages/LeagueList/View.elm
+++ b/src/Pages/LeagueList/View.elm
@@ -42,7 +42,7 @@ leagueTitle responsive league =
         [ 
             padding responsive.mediumGap
             , spacing responsive.smallGap
-            , width (percent responsive.percentageWidthToUse)
+            , width <| percent responsive.designPortraitPercentageWidth
             , class "data-test-league"
             , center
             , onClick <| IndividualSheetRequest league.title

--- a/src/Pages/LeagueTable/View.elm
+++ b/src/Pages/LeagueTable/View.elm
@@ -33,10 +33,10 @@ leagueTableElement : Responsive -> LeagueTable -> Element Styles Variations Msg
 leagueTableElement responsive leagueTable =
     let
         columns = respondedColumns 
-            responsive.viewportWidth 
+            responsive.pageWidth 
             responsive.mediumGap 
             responsive.smallGap  
-            (allColumns responsive.viewportWidth)
+            (allColumns responsive.pageWidth)
     in
         column None [ class "data-test-teams" ]
         (

--- a/src/Pages/LeagueTable/View.elm
+++ b/src/Pages/LeagueTable/View.elm
@@ -9,7 +9,7 @@ import LeagueStyleElements exposing (..)
 import Msg exposing (..)
 import Models.LeagueTable exposing (LeagueTable)
 import Models.Team exposing (..)
-import Pages.Progressive exposing (..)
+import Pages.Responsive exposing (..)
 import Pages.MaybeResponse exposing (..)
 import Pages.Page exposing (..)
 import Pages.HeaderBar exposing (..) 
@@ -17,8 +17,8 @@ import Pages.HeaderBarItem exposing (..)
 import Pages.ResponsiveColumn exposing (..)
 
 
-page : String -> WebData LeagueTable -> Progressive -> Page
-page leagueTitle response progressive =
+page : String -> WebData LeagueTable -> Responsive -> Page
+page leagueTitle response responsive =
     Page
         ( SingleHeader <| 
             HeaderBar 
@@ -26,30 +26,30 @@ page leagueTitle response progressive =
                 , ResultsFixturesHeaderButton <| IndividualSheetRequestForResultsFixtures leagueTitle ] 
                 (Maybe.withDefault "" (decodeUri leagueTitle))
                 [ RefreshHeaderButton <| IndividualSheetRequest leagueTitle ] )
-        ( maybeResponse response (leagueTableElement progressive) )
+        ( maybeResponse response (leagueTableElement responsive) )
 
 
-leagueTableElement : Progressive -> LeagueTable -> Element Styles Variations Msg
-leagueTableElement progressive leagueTable =
+leagueTableElement : Responsive -> LeagueTable -> Element Styles Variations Msg
+leagueTableElement responsive leagueTable =
     let
         columns = respondedColumns 
-            progressive.viewportWidth 
-            progressive.mediumGap 
-            progressive.smallGap  
-            (allColumns progressive.viewportWidth)
+            responsive.viewportWidth 
+            responsive.mediumGap 
+            responsive.smallGap  
+            (allColumns responsive.viewportWidth)
     in
         column None [ class "data-test-teams" ]
         (
-            [ headerRow columns progressive ]
+            [ headerRow columns responsive ]
             ++ 
-            (List.map (teamRow columns progressive) leagueTable.teams)
+            (List.map (teamRow columns responsive) leagueTable.teams)
         )
 
-headerRow : List Column -> Progressive -> Element Styles Variations Msg
-headerRow tableColumns progressive = 
+headerRow : List Column -> Responsive -> Element Styles Variations Msg
+headerRow tableColumns responsive = 
     row 
         LeagueTableHeaderRow 
-        [ padding progressive.mediumGap, spacing progressive.smallGap, center ] 
+        [ padding responsive.mediumGap, spacing responsive.smallGap, center ] 
         (List.map headerCell tableColumns)
 
 headerCell : Column -> Element Styles Variations Msg
@@ -59,11 +59,11 @@ headerCell column =
         [ width (px column.width), class column.cssClass ] 
         (text column.title)
 
-teamRow : List Column -> Progressive -> Team -> Element Styles Variations Msg
-teamRow tableColumns progressive team = 
+teamRow : List Column -> Responsive -> Team -> Element Styles Variations Msg
+teamRow tableColumns responsive team = 
     row 
         LeagueTableTeamRow 
-        [ padding progressive.mediumGap, spacing progressive.smallGap, center, class "data-test-team" ] 
+        [ padding responsive.mediumGap, spacing responsive.smallGap, center, class "data-test-team" ] 
         (List.map (teamCell team) tableColumns)
 
 teamCell : Team -> Column -> Element Styles Variations Msg

--- a/src/Pages/RenderPage.elm
+++ b/src/Pages/RenderPage.elm
@@ -11,55 +11,55 @@ import Msg exposing (..)
 import Pages.Page exposing (..)
 import Pages.HeaderBar exposing (..)
 import Pages.HeaderBarItem exposing (..)
-import Pages.Progressive exposing (..)
+import Pages.Responsive exposing (..)
 
-renderPage: Progressive -> Page -> Html Msg
-renderPage progressive page =
+renderPage: Responsive -> Page -> Html Msg
+renderPage responsive page =
     body 
-        progressive  
+        responsive  
         [
-            renderHeaderBar progressive page.header
+            renderHeaderBar responsive page.header
             , page.body
         ]
 
-body: Progressive -> List (Element Styles variation msg) -> Html msg
-body progressive elements = 
-    Element.layout (stylesheet progressive.fontSize) <|         
+body: Responsive -> List (Element Styles variation msg) -> Html msg
+body responsive elements = 
+    Element.layout (stylesheet responsive.fontSize) <|         
         column 
             Body 
-            [ width (percent 100), spacing progressive.mediumGap, center ]
+            [ width (percent 100), spacing responsive.mediumGap, center ]
             elements
 
-renderHeaderBar: Progressive -> PageHeader -> Element.Element Styles variation Msg
-renderHeaderBar progressive pageHeader = 
+renderHeaderBar: Responsive -> PageHeader -> Element.Element Styles variation Msg
+renderHeaderBar responsive pageHeader = 
     case pageHeader of
         SingleHeader headerBar ->
-            renderMainHeaderBar progressive headerBar
+            renderMainHeaderBar responsive headerBar
         DoubleHeader headerBar subHeaderBar ->
-            renderMainAndSubHeaderBar progressive headerBar subHeaderBar
+            renderMainAndSubHeaderBar responsive headerBar subHeaderBar
 
-renderMainAndSubHeaderBar: Progressive -> HeaderBar -> SubHeaderBar -> Element.Element Styles variation Msg
-renderMainAndSubHeaderBar progressive headerBar subHeaderBar =
+renderMainAndSubHeaderBar: Responsive -> HeaderBar -> SubHeaderBar -> Element.Element Styles variation Msg
+renderMainAndSubHeaderBar responsive headerBar subHeaderBar =
     column 
         Title
         [ width (percent 100) ]
-        [ renderMainHeaderBar progressive headerBar
-          , renderSubHeaderBar progressive subHeaderBar ]
+        [ renderMainHeaderBar responsive headerBar
+          , renderSubHeaderBar responsive subHeaderBar ]
 
 
-renderMainHeaderBar: Progressive -> HeaderBar -> Element.Element Styles variation Msg
-renderMainHeaderBar progressive headerBar = 
+renderMainHeaderBar: Responsive -> HeaderBar -> Element.Element Styles variation Msg
+renderMainHeaderBar responsive headerBar = 
     heading
-        progressive
+        responsive
         (List.map renderHeaderBarItem headerBar.leftItems
             ++ [ title headerBar.title ]
             ++ List.map renderHeaderBarItem headerBar.rightItems)
 
-renderSubHeaderBar: Progressive -> SubHeaderBar -> Element.Element Styles variation Msg
-renderSubHeaderBar progressive subHeaderBar = 
+renderSubHeaderBar: Responsive -> SubHeaderBar -> Element.Element Styles variation Msg
+renderSubHeaderBar responsive subHeaderBar = 
     el 
         SubTitle 
-        [ width (percent 100), padding progressive.mediumGap, verticalCenter ]
+        [ width (percent 100), padding responsive.mediumGap, verticalCenter ]
         (text subHeaderBar.title)
 
 renderHeaderBarItem: HeaderBarItem -> Element.Element Styles variation Msg
@@ -74,15 +74,15 @@ renderHeaderBarItem headerBarItem =
         BackHeaderButton msg ->
             el TitleButton [ onClick msg ] backIcon
 
-heading: Progressive -> List (Element Styles variation msg) -> Element.Element Styles variation msg
-heading progressive elements = 
+heading: Responsive -> List (Element Styles variation msg) -> Element.Element Styles variation msg
+heading responsive elements = 
     row 
         Title 
-        [ width (percent 100), padding progressive.bigGap, verticalCenter, center ] 
+        [ width (percent 100), padding responsive.bigGap, verticalCenter, center ] 
         [
             row 
                 None 
-                [ center, spacing progressive.bigGap, width (percent 100) ]
+                [ center, spacing responsive.bigGap, width (percent 100) ]
                 elements
         ]
 

--- a/src/Pages/RenderPage.elm
+++ b/src/Pages/RenderPage.elm
@@ -27,12 +27,24 @@ body responsive elements =
     Element.layout (stylesheet responsive.fontSize) <|         
         column 
             Body 
-            [ width <| px responsive.pageWidth
+            [ width <| bodyWidth responsive
             , spacingXY 0 responsive.mediumGap
             , center 
             , Element.Attributes.class "data-class-body"
             ]
             elements
+
+-- 100% normally works better, as it takes into account a vertical scroll bar if there is one. 
+-- If you just set a pixel width, it will be wider than the available width if there is a 
+-- vertical scroll bar, and then yout get an annoying horizontal scroll bar as well.
+-- If 100% is too small, then we can just use a percent value, as there is going to be a 
+-- horizontal scroll bar anyway
+bodyWidth : Responsive -> Length
+bodyWidth responsive = 
+    if responsive.pageWidth > responsive.viewportWidth then
+        px responsive.pageWidth
+    else
+        percent 100
 
 renderHeaderBar: Responsive -> PageHeader -> Element.Element Styles variation Msg
 renderHeaderBar responsive pageHeader = 

--- a/src/Pages/RenderPage.elm
+++ b/src/Pages/RenderPage.elm
@@ -27,7 +27,11 @@ body responsive elements =
     Element.layout (stylesheet responsive.fontSize) <|         
         column 
             Body 
-            [ width (percent 100), spacing responsive.mediumGap, center ]
+            [ width <| px responsive.pageWidth
+            , spacingXY 0 responsive.mediumGap
+            , center 
+            , Element.Attributes.class "data-class-body"
+            ]
             elements
 
 renderHeaderBar: Responsive -> PageHeader -> Element.Element Styles variation Msg
@@ -42,7 +46,7 @@ renderMainAndSubHeaderBar: Responsive -> HeaderBar -> SubHeaderBar -> Element.El
 renderMainAndSubHeaderBar responsive headerBar subHeaderBar =
     column 
         Title
-        [ width (percent 100) ]
+        [ width <| percent 100 ]
         [ renderMainHeaderBar responsive headerBar
           , renderSubHeaderBar responsive subHeaderBar ]
 
@@ -59,7 +63,9 @@ renderSubHeaderBar: Responsive -> SubHeaderBar -> Element.Element Styles variati
 renderSubHeaderBar responsive subHeaderBar = 
     el 
         SubTitle 
-        [ width (percent 100), padding responsive.mediumGap, verticalCenter ]
+        [ width <| percent 100
+        , padding responsive.mediumGap
+        , verticalCenter ]
         (text subHeaderBar.title)
 
 renderHeaderBarItem: HeaderBarItem -> Element.Element Styles variation Msg
@@ -78,13 +84,14 @@ heading: Responsive -> List (Element Styles variation msg) -> Element.Element St
 heading responsive elements = 
     row 
         Title 
-        [ width (percent 100), padding responsive.bigGap, verticalCenter, center ] 
-        [
-            row 
-                None 
-                [ center, spacing responsive.bigGap, width (percent 100) ]
-                elements
-        ]
+        [ width <| percent 100
+        , padding responsive.bigGap
+        , spacing responsive.bigGap
+        , verticalCenter
+        , center
+        , Element.Attributes.class "data-class-heading"
+        ] 
+        elements
 
 title: String -> Element.Element Styles variation msg
 title titleText = 

--- a/src/Pages/RenderPage.elm
+++ b/src/Pages/RenderPage.elm
@@ -95,7 +95,7 @@ heading responsive elements =
 
 title: String -> Element.Element Styles variation msg
 title titleText = 
-    el Title [ width fill ] (text titleText)
+    paragraph Title [ width fill ] [text titleText]
 
 
 backIcon : Element style variation msg

--- a/src/Pages/Responsive.elm
+++ b/src/Pages/Responsive.elm
@@ -1,11 +1,17 @@
 module Pages.Responsive exposing (Responsive, FontSize, calculateResponsive, vanillaResponsive)
 
+-- Pixel widths, with one character spare, measured using https://codepen.io/jasesmith/pen/eBeoNz
 type alias Responsive =
     { bigGap: Float
     , mediumGap: Float
     , smallGap: Float
+    , viewportWidth : Float
     , pageWidth : Float
     , fontSize: FontSize
+    -- designTeamWidths are the width that a team should ideally be able to be displayed on one line,
+    -- "Blackwater_Bandits" is used as the text for this theoretical long team name. Team names 
+    -- longer than this can wrap or display an ellipsis. If pages need to wrap at shorter widths then
+    -- that is ok too, it is a guide, not a rule
     , designTeamWidthMediumFont : Float
     -- if the content is essentiallyl portrait, try and extend out to this percentage width
     , designPortraitPercentageWidth : Float    
@@ -17,18 +23,13 @@ type alias FontSize =
     , small: Float    
     }
 
--- Pixel widths, with one character spare, measured using https://codepen.io/jasesmith/pen/eBeoNz
--- designTeamWidths are the width that a team should ideally be able to be displayed on one line,
--- "Blackwater_Bandits" is used as the text for this theoretical long team name. Team names 
--- longer than this can wrap or display an ellipsis. If pages need to wrap at shorter widths then
--- that is ok too, it is a guide, not a rule
-
 calculateResponsive : Float -> Responsive
 calculateResponsive viewportWidth =
     if viewportWidth <= 600 then
         { bigGap = 12
         , mediumGap = 5
         , smallGap = 3  
+        , viewportWidth = viewportWidth
         , pageWidth = calculatePageWidth viewportWidth
         , fontSize = 
             { big = 24
@@ -42,6 +43,7 @@ calculateResponsive viewportWidth =
         { bigGap = 18
         , mediumGap = 8
         , smallGap = 5    
+        , viewportWidth = viewportWidth
         , pageWidth = calculatePageWidth viewportWidth
         , fontSize = 
             { big = 29
@@ -55,6 +57,7 @@ calculateResponsive viewportWidth =
         { bigGap = 24
         , mediumGap = 10
         , smallGap = 6    
+        , viewportWidth = viewportWidth
         , pageWidth = calculatePageWidth viewportWidth
         , fontSize = 
             { big = 34
@@ -68,6 +71,7 @@ calculateResponsive viewportWidth =
         { bigGap = 30
         , mediumGap = 13
         , smallGap = 8    
+        , viewportWidth = viewportWidth
         , pageWidth = calculatePageWidth viewportWidth
         , fontSize = 
             { big = 48

--- a/src/Pages/Responsive.elm
+++ b/src/Pages/Responsive.elm
@@ -1,6 +1,6 @@
-module Pages.Progressive exposing (Progressive, FontSize, calculateProgressive, vanillaProgressive)
+module Pages.Responsive exposing (Responsive, FontSize, calculateResponsive, vanillaResponsive)
 
-type alias Progressive =
+type alias Responsive =
     { bigGap: Float
     , mediumGap: Float
     , smallGap: Float
@@ -22,8 +22,8 @@ type alias FontSize =
 -- longer than this can wrap or display an ellipsis. If pages need to wrap at shorter widths then
 -- that is ok too, it is a guide, not a rule
 
-calculateProgressive : Float -> Progressive
-calculateProgressive viewportWidth =
+calculateResponsive : Float -> Responsive
+calculateResponsive viewportWidth =
     if viewportWidth <= 600 then
         { bigGap = 12
         , mediumGap = 5
@@ -88,6 +88,6 @@ calculateFontSize width =
         , small = 24    
         }
 
-vanillaProgressive : Progressive
-vanillaProgressive =
-    calculateProgressive 1024.0 
+vanillaResponsive : Responsive
+vanillaResponsive =
+    calculateResponsive 1024.0 

--- a/src/Pages/Responsive.elm
+++ b/src/Pages/Responsive.elm
@@ -5,9 +5,9 @@ type alias Responsive =
     , mediumGap: Float
     , smallGap: Float
     , viewportWidth : Float
+    , fontSize: FontSize
     , designTeamWidthMediumFont : Float
     , percentageWidthToUse : Float    
-    , fontSize: FontSize
     }
 
 type alias FontSize =
@@ -29,63 +29,52 @@ calculateResponsive viewportWidth =
         , mediumGap = 5
         , smallGap = 3  
         , viewportWidth = viewportWidth
-        -- 14px font 
-        , designTeamWidthMediumFont = 141  
         , percentageWidthToUse = 95
-        , fontSize = calculateFontSize viewportWidth
+        , fontSize = 
+            { big = 24
+            , medium = 14
+            , small = 12    
+            }
+        , designTeamWidthMediumFont = 141  
         }
     else if viewportWidth <= 1200 then
         { bigGap = 18
         , mediumGap = 8
         , smallGap = 5    
         , viewportWidth = viewportWidth
-        -- 19px font
+        , fontSize = 
+            { big = 29
+            , medium = 19
+            , small = 15    
+            }
         , designTeamWidthMediumFont = 191  
         , percentageWidthToUse = 80
-        , fontSize = calculateFontSize viewportWidth
         }
     else if viewportWidth <= 1800 then
         { bigGap = 24
         , mediumGap = 10
         , smallGap = 6    
         , viewportWidth = viewportWidth
-        -- 25px font
+        , fontSize = 
+            { big = 34
+            , medium = 25
+            , small = 18    
+            }
         , designTeamWidthMediumFont = 252  
         , percentageWidthToUse = 60
-        , fontSize = calculateFontSize viewportWidth
         }
     else 
         { bigGap = 30
         , mediumGap = 13
         , smallGap = 8    
         , viewportWidth = viewportWidth
-        -- 32px font
+        , fontSize = 
+            { big = 48
+            , medium = 32
+            , small = 24    
+            }
         , designTeamWidthMediumFont = 322 
         , percentageWidthToUse = 60
-        , fontSize = calculateFontSize viewportWidth
-        }
-
-calculateFontSize: Float -> FontSize
-calculateFontSize width =
-    if width <= 600 then
-        { big = 24
-        , medium = 14
-        , small = 12    
-        }
-    else if width <= 1200 then
-        { big = 29
-        , medium = 19
-        , small = 15    
-        }
-    else if width <= 1800 then
-        { big = 34
-        , medium = 25
-        , small = 18    
-        }
-    else 
-        { big = 48
-        , medium = 32
-        , small = 24    
         }
 
 vanillaResponsive : Responsive

--- a/src/Pages/Responsive.elm
+++ b/src/Pages/Responsive.elm
@@ -4,10 +4,11 @@ type alias Responsive =
     { bigGap: Float
     , mediumGap: Float
     , smallGap: Float
-    , viewportWidth : Float
+    , pageWidth : Float
     , fontSize: FontSize
     , designTeamWidthMediumFont : Float
-    , percentageWidthToUse : Float    
+    -- if the content is essentiallyl portrait, try and extend out to this percentage width
+    , designPortraitPercentageWidth : Float    
     }
 
 type alias FontSize =
@@ -28,54 +29,61 @@ calculateResponsive viewportWidth =
         { bigGap = 12
         , mediumGap = 5
         , smallGap = 3  
-        , viewportWidth = viewportWidth
-        , percentageWidthToUse = 95
+        , pageWidth = calculatePageWidth viewportWidth
         , fontSize = 
             { big = 24
             , medium = 14
             , small = 12    
             }
         , designTeamWidthMediumFont = 141  
+        , designPortraitPercentageWidth = 95
         }
     else if viewportWidth <= 1200 then
         { bigGap = 18
         , mediumGap = 8
         , smallGap = 5    
-        , viewportWidth = viewportWidth
+        , pageWidth = calculatePageWidth viewportWidth
         , fontSize = 
             { big = 29
             , medium = 19
             , small = 15    
             }
         , designTeamWidthMediumFont = 191  
-        , percentageWidthToUse = 80
+        , designPortraitPercentageWidth = 60
         }
     else if viewportWidth <= 1800 then
         { bigGap = 24
         , mediumGap = 10
         , smallGap = 6    
-        , viewportWidth = viewportWidth
+        , pageWidth = calculatePageWidth viewportWidth
         , fontSize = 
             { big = 34
             , medium = 25
             , small = 18    
             }
         , designTeamWidthMediumFont = 252  
-        , percentageWidthToUse = 60
+        , designPortraitPercentageWidth = 60
         }
     else 
         { bigGap = 30
         , mediumGap = 13
         , smallGap = 8    
-        , viewportWidth = viewportWidth
+        , pageWidth = calculatePageWidth viewportWidth
         , fontSize = 
             { big = 48
             , medium = 32
             , small = 24    
             }
         , designTeamWidthMediumFont = 322 
-        , percentageWidthToUse = 60
+        , designPortraitPercentageWidth = 60
         }
+
+calculatePageWidth : Float -> Float
+calculatePageWidth viewportWidth =
+    if viewportWidth < 200 then
+        200
+    else
+        viewportWidth
 
 vanillaResponsive : Responsive
 vanillaResponsive =

--- a/src/Pages/ResultsFixtures/View.elm
+++ b/src/Pages/ResultsFixtures/View.elm
@@ -143,7 +143,7 @@ timeDisplay maybeDate =
 
 dayWidth: Responsive -> Element.Attribute variation msg
 dayWidth responsive = 
-    if responsive.designTeamWidthMediumFont * 2.5 < responsive.viewportWidth * 0.8 then 
+    if responsive.designTeamWidthMediumFont * 2.5 < responsive.pageWidth * 0.8 then 
         width <| percent 80
     else 
         width <| percent 100

--- a/src/Pages/ResultsFixtures/View.elm
+++ b/src/Pages/ResultsFixtures/View.elm
@@ -7,7 +7,7 @@ import Http exposing (decodeUri)
 
 import Date exposing (..)
 import Date.Extra exposing (..)
-import Pages.Progressive exposing (..)
+import Pages.Responsive exposing (..)
 import LeagueStyleElements exposing (..)
 import Msg exposing (..)
 import Models.LeagueGamesForDay exposing (LeagueGamesForDay)
@@ -19,7 +19,7 @@ import Pages.HeaderBar exposing (..)
 import Pages.HeaderBarItem exposing (..)
 
 
-page : String -> WebData ResultsFixtures -> Progressive -> Page
+page : String -> WebData ResultsFixtures -> Responsive -> Page
 page leagueTitle response progessive =
     Page
         ( DoubleHeader  
@@ -34,27 +34,27 @@ headerBar leagueTitle =
         (Maybe.withDefault "" (decodeUri leagueTitle))
         [ RefreshHeaderButton <| IndividualSheetRequestForResultsFixtures leagueTitle ]
 
-fixturesResultsElement : Progressive -> ResultsFixtures -> Element Styles variation Msg
-fixturesResultsElement progressive resultsFixtures =
+fixturesResultsElement : Responsive -> ResultsFixtures -> Element Styles variation Msg
+fixturesResultsElement responsive resultsFixtures =
     column 
         None 
         [ class "data-test-dates"
         , width <| percent 100
         , center 
         ]
-        (List.map (day progressive) resultsFixtures.days)
+        (List.map (day responsive) resultsFixtures.days)
 
-day : Progressive -> LeagueGamesForDay -> Element Styles variation Msg
-day progressive leagueGamesForDay =
+day : Responsive -> LeagueGamesForDay -> Element Styles variation Msg
+day responsive leagueGamesForDay =
     column 
         None 
-        [ padding progressive.mediumGap
-        , spacing progressive.mediumGap
-        , dayWidth progressive
+        [ padding responsive.mediumGap
+        , spacing responsive.mediumGap
+        , dayWidth responsive
         , class <| "data-test-day data-test-date-" ++ (dateClassNamePart leagueGamesForDay.date)
         ]
         [ dayHeader leagueGamesForDay.date
-        , dayResultsFixtures progressive leagueGamesForDay
+        , dayResultsFixtures responsive leagueGamesForDay
         ] 
 
 dayHeader : Maybe Date -> Element Styles variation Msg
@@ -64,28 +64,28 @@ dayHeader maybeDate =
         [ class "data-test-dayHeader" ] 
         (text <| dateDisplay maybeDate)
 
-dayResultsFixtures : Progressive -> LeagueGamesForDay -> Element Styles variation Msg
-dayResultsFixtures progressive leagueGamesForDay =
+dayResultsFixtures : Responsive -> LeagueGamesForDay -> Element Styles variation Msg
+dayResultsFixtures responsive leagueGamesForDay =
     column 
         None 
         [ width <| percent 100
-        , spacing progressive.smallGap
+        , spacing responsive.smallGap
         ]
-        (List.map (gameRow progressive) leagueGamesForDay.games)
+        (List.map (gameRow responsive) leagueGamesForDay.games)
 
-gameRow : Progressive -> Game -> Element Styles variation Msg
-gameRow progressive game =
+gameRow : Responsive -> Game -> Element Styles variation Msg
+gameRow responsive game =
     row 
         ResultFixtureRow 
         [ padding 0
-        , spacing progressive.mediumGap
+        , spacing responsive.mediumGap
         , center
         , class "data-test-game"
         , width <| percent 100 ] 
         [ 
             paragraph 
                 ResultFixtureHome 
-                [ alignRight, teamWidth progressive, class "data-test-homeTeamName" ] 
+                [ alignRight, teamWidth responsive, class "data-test-homeTeamName" ] 
                 [ text game.homeTeamName ]
             , row 
                 None 
@@ -93,7 +93,7 @@ gameRow progressive game =
                 ( scoreSlashTime game )
             , paragraph 
                 ResultFixtureAway 
-                [ alignLeft, teamWidth progressive, class "data-test-awayTeamName" ] 
+                [ alignLeft, teamWidth responsive, class "data-test-awayTeamName" ] 
                 [ text game.awayTeamName ]
         ]
 
@@ -141,13 +141,13 @@ timeDisplay maybeDate =
     |> Maybe.map (Date.Extra.toFormattedString "HH:mm")
     |> Maybe.withDefault " - "
 
-dayWidth: Progressive -> Element.Attribute variation msg
-dayWidth progressive = 
-    if progressive.designTeamWidthMediumFont * 2.5 < progressive.viewportWidth * 0.8 then 
+dayWidth: Responsive -> Element.Attribute variation msg
+dayWidth responsive = 
+    if responsive.designTeamWidthMediumFont * 2.5 < responsive.viewportWidth * 0.8 then 
         width <| percent 80
     else 
         width <| percent 100
     
-teamWidth: Progressive -> Element.Attribute variation msg
-teamWidth progressive = 
+teamWidth: Responsive -> Element.Attribute variation msg
+teamWidth responsive = 
     width <| fillPortion 50

--- a/src/Pages/ResultsFixtures/View.elm
+++ b/src/Pages/ResultsFixtures/View.elm
@@ -25,13 +25,13 @@ page leagueTitle response progessive =
         ( DoubleHeader  
             (headerBar leagueTitle)
             (SubHeaderBar "Results / Fixtures"))
-        ( maybeResponse response (fixturesResultsElement progessive) )
+        ( maybeResponse response <| fixturesResultsElement progessive )
 
 headerBar: String -> HeaderBar
 headerBar leagueTitle = 
     HeaderBar 
         [ BackHeaderButton <| IndividualSheetRequest leagueTitle ] 
-        (Maybe.withDefault "" (decodeUri leagueTitle))
+        (Maybe.withDefault "" <| decodeUri leagueTitle)
         [ RefreshHeaderButton <| IndividualSheetRequestForResultsFixtures leagueTitle ]
 
 fixturesResultsElement : Responsive -> ResultsFixtures -> Element Styles variation Msg

--- a/src/View.elm
+++ b/src/View.elm
@@ -10,27 +10,27 @@ import Pages.LeagueTable.View exposing (..)
 import Pages.ResultsFixtures.View exposing (..)
 import Pages.Page exposing (..)
 import Pages.RenderPage exposing (..)
-import Pages.Progressive exposing (..)
+import Pages.Responsive exposing (..)
 
 
 view : Model -> Html Msg
 view model =
     let
-        progressive = calculateProgressive <| toFloat model.device.width
+        responsive = calculateResponsive <| toFloat model.device.width
     in
-        renderPage progressive <| page model progressive
+        renderPage responsive <| page model responsive
 
-page : Model -> Progressive -> Page
-page model progressive =
+page : Model -> Responsive -> Page
+page model responsive =
     case model.route of
         Route.LeagueListRoute ->
-            Pages.LeagueList.View.page model.leagues progressive
+            Pages.LeagueList.View.page model.leagues responsive
         Route.LeagueTableRoute leagueTitle ->
-            Pages.LeagueTable.View.page leagueTitle model.leagueTable progressive
+            Pages.LeagueTable.View.page leagueTitle model.leagueTable responsive
         Route.ResultsFixturesRoute leagueTitle ->
-            Pages.ResultsFixtures.View.page leagueTitle model.resultsFixtures progressive
+            Pages.ResultsFixtures.View.page leagueTitle model.resultsFixtures responsive
         Route.NotFoundRoute ->
-            Pages.LeagueList.View.page model.leagues progressive -- return 404 later
+            Pages.LeagueList.View.page model.leagues responsive -- return 404 later
 
 -- notFoundView : Html msg
 -- notFoundView =

--- a/tests/CalculateFixturesResultsOrderGamesWithinDayByDateTest.elm
+++ b/tests/CalculateFixturesResultsOrderGamesWithinDayByDateTest.elm
@@ -1,4 +1,4 @@
-module CalculateFixturesResultsOrderGamesWithinDayByDate exposing (..)
+module CalculateFixturesResultsOrderGamesWithinDayByDateTest exposing (..)
 
 import Date exposing (..)
 import Date.Extra exposing (..)

--- a/tests/LeagueListUpdateTest.elm
+++ b/tests/LeagueListUpdateTest.elm
@@ -1,4 +1,4 @@
-module LeagueListUpdate exposing (..)
+module LeagueListUpdateTest exposing (..)
 
 import Http exposing (..)
 import Test exposing (..)

--- a/tests/LeagueListView.elm
+++ b/tests/LeagueListView.elm
@@ -9,7 +9,7 @@ import Fuzz exposing (list, string)
 import Pages.LeagueList.View exposing (..)
 import Pages.RenderPage exposing (..)
 import Models.LeagueSummary exposing (LeagueSummary)
-import Pages.Progressive exposing (..)
+import Pages.Responsive exposing (..)
 
 
 multipleLeagues : Test
@@ -17,8 +17,8 @@ multipleLeagues =
     fuzz (list string) "Displays multiple leagues correctly" <|
         \leagueTitles ->
                 renderPage 
-                    vanillaProgressive
-                    (page (leagueListResponse leagueTitles) vanillaProgressive)
+                    vanillaResponsive
+                    (page (leagueListResponse leagueTitles) vanillaResponsive)
                 |> Query.fromHtml
                 |> Query.has (List.map text leagueTitles)
 

--- a/tests/LeagueListViewTest.elm
+++ b/tests/LeagueListViewTest.elm
@@ -1,4 +1,4 @@
-module LeagueListView exposing (multipleLeagues)
+module LeagueListViewTest exposing (multipleLeagues)
 
 import RemoteData exposing (WebData)
 import Test exposing (..)

--- a/tests/LeagueTableUpdateTest.elm
+++ b/tests/LeagueTableUpdateTest.elm
@@ -1,4 +1,4 @@
-module LeagueTableUpdate exposing (..)
+module LeagueTableUpdateTest exposing (..)
 
 import Test exposing (..)
 import Expect

--- a/tests/LeagueTableView.elm
+++ b/tests/LeagueTableView.elm
@@ -10,7 +10,7 @@ import Pages.RenderPage exposing (..)
 import Models.Team exposing (Team)
 import Models.LeagueTable exposing (LeagueTable)
 import Msg exposing (..)
-import Pages.Progressive exposing (..)
+import Pages.Responsive exposing (..)
 
 oneTeam : Test
 oneTeam =
@@ -80,6 +80,6 @@ teamElement  =
 html : Query.Single Msg.Msg
 html  =
     renderPage 
-        vanillaProgressive
-        (page "" (RemoteData.Success (LeagueTable "" [ Team 1 "Castle" 1 1 0 0 3 6 4 2 ]))  vanillaProgressive)
+        vanillaResponsive
+        (page "" (RemoteData.Success (LeagueTable "" [ Team 1 "Castle" 1 1 0 0 3 6 4 2 ]))  vanillaResponsive)
     |> Query.fromHtml

--- a/tests/LeagueTableViewTest.elm
+++ b/tests/LeagueTableViewTest.elm
@@ -1,4 +1,4 @@
-module LeagueTableView exposing (..)
+module LeagueTableViewTest exposing (..)
 
 import Test exposing (..)
 import Test.Html.Query as Query

--- a/tests/ResultsFixturesUpdateTest.elm
+++ b/tests/ResultsFixturesUpdateTest.elm
@@ -1,4 +1,4 @@
-module ResultsFixturesUpdate exposing (..)
+module ResultsFixturesUpdateTest exposing (..)
 
 import Test exposing (..)
 import Expect

--- a/tests/ResultsFixturesViewForPlayedGameTest.elm
+++ b/tests/ResultsFixturesViewForPlayedGameTest.elm
@@ -1,4 +1,4 @@
-module ResultsFixturesViewForPlayedGame exposing (..)
+module ResultsFixturesViewForPlayedGameTest exposing (..)
 
 import Test exposing (..)
 import Test.Html.Query as Query

--- a/tests/ResultsFixturesViewForUnplayedGameTest.elm
+++ b/tests/ResultsFixturesViewForUnplayedGameTest.elm
@@ -1,4 +1,4 @@
-module ResultsFixturesViewForUnplayedGame exposing (..)
+module ResultsFixturesViewForUnplayedGameTest exposing (..)
 
 import Test exposing (..)
 import Test.Html.Query as Query

--- a/tests/ResultsFixturesViewForUnplayedGameWithNoDateTest.elm
+++ b/tests/ResultsFixturesViewForUnplayedGameWithNoDateTest.elm
@@ -1,4 +1,4 @@
-module ResultsFixturesViewForUnplayedGameWithNoDate exposing (..)
+module ResultsFixturesViewForUnplayedGameWithNoDateTest  exposing (..)
 
 import Test exposing (..)
 import Test.Html.Query as Query

--- a/tests/ResultsFixturesViewHelpers.elm
+++ b/tests/ResultsFixturesViewHelpers.elm
@@ -9,11 +9,11 @@ import Models.ResultsFixtures exposing (ResultsFixtures)
 import Models.Game exposing (Game)
 import Models.LeagueGamesForDay exposing (LeagueGamesForDay)
 import Msg exposing (..)
-import Pages.Progressive exposing (..)
+import Pages.Responsive exposing (..)
 
 html :  Game -> Query.Single Msg
 html game  =
     renderPage 
-        vanillaProgressive
-        (page "" (RemoteData.Success (ResultsFixtures "" [ LeagueGamesForDay game.datePlayed [ game ] ]))  vanillaProgressive)
+        vanillaResponsive
+        (page "" (RemoteData.Success (ResultsFixtures "" [ LeagueGamesForDay game.datePlayed [ game ] ]))  vanillaResponsive)
     |> Query.fromHtml


### PR DESCRIPTION
The widths were all supposed to be 100% of screen or less, but there was still a horizontal scrollbar appearing for 5 pixels or so. This was due to a spacing on the body el, so I changed to using a spacingXY and set the x spacing to 0.

Widths under 200px are a bit pointless, and make it increasingly hard to get a sensible responsive layout. It wasn't really working before at very low widths, but now it works at all widths, and adds a horizontal scroll bar if the width is less than 200px.

There is also some minor code tidy up