### PR TITLE
Only call api if data does not already exist, fix back button

### DIFF
--- a/EndToEndTests/SpreadsheetValuesWithDataEntryIssuesResponse.elm
+++ b/EndToEndTests/SpreadsheetValuesWithDataEntryIssuesResponse.elm
@@ -3,7 +3,7 @@ module SpreadsheetValuesWithDataEntryIssuesResponse exposing (spreadsheetValuesW
 import ApiResponseFragments exposing (..)
 
 -- This is the based on the response from the test spreadsheet, at https://sheets.googleapis.com/v4/spreadsheets/1Ai9H6Pfe1LPsOcksN6EF03-z-gO1CkNp8P1Im37N3TE/values/Regional%20Div%201?key=<thekey>
--- The first row should be parsed successfully
+-- The first row should be parsed successfully, but the whitespace should be trimmed from the team names
 -- There is a row with only 3 cells, which isn't enough information so should be ignore
 -- There is a row with enough cells, but a blank team name, this should also be ignored
 spreadsheetValuesWithDataEntryIssuesResponse: String
@@ -15,10 +15,10 @@ spreadsheetValuesWithDataEntryIssuesResponse =
   """
   ++ completeHeaderRow ++
   """, [
-        "Castle",
+        " Castle",
         "1",
         "0",
-        "Meridian"
+        "Meridian "
       ],
       [
         "asd",

--- a/src/Models/Game.elm
+++ b/src/Models/Game.elm
@@ -1,4 +1,4 @@
-module Models.Game exposing (Game)
+module Models.Game exposing (Game, vanillaGame)
 
 import Date exposing (..)
 
@@ -14,3 +14,7 @@ type alias Game =
     , awayCards : String
     , notes : String
     }
+
+vanillaGame : Game
+vanillaGame = 
+    Game "" Nothing "" Nothing Nothing "" "" "" "" "" 

--- a/src/Models/LeagueTable.elm
+++ b/src/Models/LeagueTable.elm
@@ -1,4 +1,4 @@
-module Models.LeagueTable exposing (LeagueTable)
+module Models.LeagueTable exposing (LeagueTable, vanillaLeagueTable)
 
 import Models.Team exposing (Team)
 
@@ -7,3 +7,7 @@ type alias LeagueTable =
     { title : String
     , teams : List Team
     }
+
+vanillaLeagueTable : LeagueTable
+vanillaLeagueTable = 
+    LeagueTable "" []

--- a/src/Models/Model.elm
+++ b/src/Models/Model.elm
@@ -1,5 +1,6 @@
 module Models.Model exposing (..)
 
+import Dict exposing (Dict)
 import RemoteData exposing (WebData)
 
 import Models.LeagueSummary exposing (LeagueSummary)
@@ -15,7 +16,7 @@ type alias Model =
     { config: Config
     , route: Route
     , leagues: WebData (List LeagueSummary)
-    , leagueTable: WebData (LeagueTable)
+    , leagueTables: Dict String (WebData LeagueTable)
     , leagueGames: WebData (LeagueGames)
     , resultsFixtures: WebData (ResultsFixtures)
     , device: Device
@@ -27,7 +28,7 @@ vanillaModel =
         (Config "" "") 
         Route.NotFoundRoute 
         RemoteData.NotAsked 
-        RemoteData.NotAsked 
+        Dict.empty
         RemoteData.NotAsked 
         RemoteData.NotAsked 
         (classifyDevice <| Window.Size 1024 768)

--- a/src/Models/Model.elm
+++ b/src/Models/Model.elm
@@ -5,7 +5,6 @@ import RemoteData exposing (WebData)
 
 import Models.LeagueSummary exposing (LeagueSummary)
 import Models.LeagueTable exposing (LeagueTable)
-import Models.LeagueGames exposing (LeagueGames)
 import Models.ResultsFixtures exposing (ResultsFixtures)
 import Models.Config exposing (Config)
 import Models.Route as Route exposing (Route)
@@ -17,8 +16,7 @@ type alias Model =
     , route: Route
     , leagues: WebData (List LeagueSummary)
     , leagueTables: Dict String (WebData LeagueTable)
-    , leagueGames: WebData (LeagueGames)
-    , resultsFixtures: WebData (ResultsFixtures)
+    , resultsFixturess: Dict String (WebData ResultsFixtures)
     , device: Device
     }
 
@@ -29,6 +27,5 @@ vanillaModel =
         Route.NotFoundRoute 
         RemoteData.NotAsked 
         Dict.empty
-        RemoteData.NotAsked 
-        RemoteData.NotAsked 
+        Dict.empty
         (classifyDevice <| Window.Size 1024 768)

--- a/src/Models/Model.elm
+++ b/src/Models/Model.elm
@@ -16,7 +16,7 @@ type alias Model =
     , route: Route
     , leagues: WebData (List LeagueSummary)
     , leagueTables: Dict String (WebData LeagueTable)
-    , resultsFixturess: Dict String (WebData ResultsFixtures)
+    , resultsFixtures: Dict String (WebData ResultsFixtures)
     , device: Device
     }
 

--- a/src/Models/Model.elm
+++ b/src/Models/Model.elm
@@ -24,7 +24,7 @@ vanillaModel : Model
 vanillaModel =
     Model 
         (Config "" "") 
-        Route.NotFoundRoute 
+        Route.NotFound 
         RemoteData.NotAsked 
         Dict.empty
         Dict.empty

--- a/src/Models/ResultsFixtures.elm
+++ b/src/Models/ResultsFixtures.elm
@@ -1,4 +1,4 @@
-module Models.ResultsFixtures exposing (ResultsFixtures)
+module Models.ResultsFixtures exposing (ResultsFixtures, vanillaResultsFixtures)
 
 import Models.LeagueGamesForDay exposing (LeagueGamesForDay)
 
@@ -7,3 +7,11 @@ type alias ResultsFixtures =
     { leagueTitle : String
     , days : List LeagueGamesForDay
     }
+
+vanillaResultsFixtures : ResultsFixtures
+vanillaResultsFixtures = 
+    ResultsFixtures 
+        ""
+        [ 
+            LeagueGamesForDay Nothing []
+        ]

--- a/src/Models/Route.elm
+++ b/src/Models/Route.elm
@@ -1,7 +1,7 @@
 module Models.Route exposing (..)
 
 type Route
-    = LeagueListRoute
-    | LeagueTableRoute String -- change String to LeagueId later
-    | ResultsFixturesRoute String -- change String to LeagueId later
-    | NotFoundRoute
+    = LeagueList
+    | LeagueTable String -- change String to LeagueId later
+    | ResultsFixtures String -- change String to LeagueId later
+    | NotFound

--- a/src/Msg.elm
+++ b/src/Msg.elm
@@ -14,11 +14,12 @@ type Msg
     ShowLeagueList
     | RefreshLeagueList
     | AllSheetSummaryResponse (WebData (List LeagueSummary))
-    -- LeagueTable
-    | IndividualSheetRequest String
+    -- Fixtures / Results, LeagueTable
+    | ShowLeagueTable String
+    | RefreshLeagueTable String
+    | ShowResultsFixtures String
+    | RefreshResultsFixtures String
     | IndividualSheetResponse String (WebData LeagueGames)
-    -- Fixtures / Results
-    | IndividualSheetRequestForResultsFixtures String
     -- routing
     | OnLocationChange Location
     -- responsiveness

--- a/src/Msg.elm
+++ b/src/Msg.elm
@@ -19,7 +19,6 @@ type Msg
     | IndividualSheetResponse String (WebData LeagueGames)
     -- Fixtures / Results
     | IndividualSheetRequestForResultsFixtures String
-    | IndividualSheetResponseForResultsFixtures String (WebData LeagueGames)
     -- routing
     | OnLocationChange Location
     -- responsiveness

--- a/src/Msg.elm
+++ b/src/Msg.elm
@@ -11,7 +11,8 @@ import Navigation exposing (Location)
 type Msg
     = 
     -- league List
-    AllSheetSummaryRequest
+    ShowLeagueList
+    | RefreshLeagueList
     | AllSheetSummaryResponse (WebData (List LeagueSummary))
     -- LeagueTable
     | IndividualSheetRequest String

--- a/src/Pages/LeagueList/Update.elm
+++ b/src/Pages/LeagueList/Update.elm
@@ -1,13 +1,11 @@
 module Pages.LeagueList.Update exposing (showLeagueList, refreshLeagueList, allSheetSummaryResponse)
 
-import Navigation exposing (newUrl)
 import RemoteData exposing (WebData)
 
 import Msg exposing (..)
 import Models.Model exposing (Model)
 import Models.LeagueSummary exposing (LeagueSummary)
 import Models.Route as Route exposing (Route)
-import Routing exposing (toUrl)
 import GoogleSheet.Api exposing (fetchLeagueSummaries)
 
 showLeagueList : Model -> ( Model, Cmd Msg )
@@ -31,5 +29,5 @@ refreshLeagueList model =
 
 allSheetSummaryResponse: Model -> WebData (List LeagueSummary) -> ( Model, Cmd Msg )
 allSheetSummaryResponse model response = 
-    ( { model | leagues = response }, newUrl <| toUrl <| model.route )
+    ( { model | leagues = response }, Cmd.none )
 

--- a/src/Pages/LeagueList/Update.elm
+++ b/src/Pages/LeagueList/Update.elm
@@ -1,4 +1,4 @@
-module Pages.LeagueList.Update exposing (allSheetSummaryRequest, allSheetSummaryResponse)
+module Pages.LeagueList.Update exposing (showLeagueList, refreshLeagueList,  allSheetSummaryResponse)
 
 import Navigation exposing (newUrl)
 import RemoteData exposing (WebData)
@@ -10,13 +10,23 @@ import Models.Route as Route exposing (Route)
 import Routing exposing (toUrl)
 import GoogleSheet.Api exposing (fetchLeagueSummaries)
 
+showLeagueList : Model -> ( Model, Cmd Msg )
+showLeagueList model =
+    let
+        modelWithRoute = { model | route = Route.LeagueListRoute }
+    in
+        case model.leagues of
+            RemoteData.Success _ ->
+                (modelWithRoute, Cmd.none)
+            RemoteData.Loading ->
+                (modelWithRoute, Cmd.none)
+            _ ->
+                refreshLeagueList modelWithRoute
 
-allSheetSummaryRequest : Model -> ( Model, Cmd Msg )
-allSheetSummaryRequest model =
-    ( { model | 
-            leagues = RemoteData.Loading
-            , route = Route.LeagueListRoute 
-      }
+
+refreshLeagueList : Model -> ( Model, Cmd Msg )
+refreshLeagueList model =
+    ( { model | leagues = RemoteData.Loading}
       , fetchLeagueSummaries model.config AllSheetSummaryResponse )
 
 allSheetSummaryResponse: Model -> WebData (List LeagueSummary) -> ( Model, Cmd Msg )

--- a/src/Pages/LeagueList/Update.elm
+++ b/src/Pages/LeagueList/Update.elm
@@ -26,7 +26,7 @@ showLeagueList model =
 
 refreshLeagueList : Model -> ( Model, Cmd Msg )
 refreshLeagueList model =
-    ( { model | leagues = RemoteData.Loading}
+    ( { model | leagues = RemoteData.Loading }
       , fetchLeagueSummaries model.config AllSheetSummaryResponse )
 
 allSheetSummaryResponse: Model -> WebData (List LeagueSummary) -> ( Model, Cmd Msg )

--- a/src/Pages/LeagueList/Update.elm
+++ b/src/Pages/LeagueList/Update.elm
@@ -1,4 +1,4 @@
-module Pages.LeagueList.Update exposing (showLeagueList, refreshLeagueList,  allSheetSummaryResponse)
+module Pages.LeagueList.Update exposing (showLeagueList, refreshLeagueList, allSheetSummaryResponse)
 
 import Navigation exposing (newUrl)
 import RemoteData exposing (WebData)

--- a/src/Pages/LeagueList/Update.elm
+++ b/src/Pages/LeagueList/Update.elm
@@ -13,7 +13,7 @@ import GoogleSheet.Api exposing (fetchLeagueSummaries)
 showLeagueList : Model -> ( Model, Cmd Msg )
 showLeagueList model =
     let
-        modelWithRoute = { model | route = Route.LeagueListRoute }
+        modelWithRoute = { model | route = Route.LeagueList }
     in
         case model.leagues of
             RemoteData.Success _ ->

--- a/src/Pages/LeagueList/View.elm
+++ b/src/Pages/LeagueList/View.elm
@@ -45,7 +45,7 @@ leagueTitle responsive league =
             , width <| percent responsive.designPortraitPercentageWidth
             , class "data-test-league"
             , center
-            , onClick <| IndividualSheetRequest league.title
+            , onClick <| ShowLeagueTable league.title
         ] 
         (paragraph None [] [ text league.title ] )
  

--- a/src/Pages/LeagueList/View.elm
+++ b/src/Pages/LeagueList/View.elm
@@ -22,7 +22,7 @@ page response responsive =
             HeaderBar 
                 [ HeaderButtonSizedSpace ] 
                 "Leagues" 
-                [ RefreshHeaderButton AllSheetSummaryRequest ] )
+                [ RefreshHeaderButton RefreshLeagueList ] )
         ( maybeResponse response <| leagueList responsive )
 
 leagueList: Responsive -> List LeagueSummary -> Element Styles variation Msg

--- a/src/Pages/LeagueTable/Update.elm
+++ b/src/Pages/LeagueTable/Update.elm
@@ -1,35 +1,13 @@
-module Pages.LeagueTable.Update exposing (individualSheetRequest, individualSheetResponse)
-
-import Navigation exposing (newUrl)
-import RemoteData exposing (WebData)
+module Pages.LeagueTable.Update exposing (individualSheetRequest)
 
 import Msg exposing (..)
 import Models.Model exposing (Model)
-import Models.LeagueGames exposing (LeagueGames)
-import Models.Config exposing (Config)
 import Models.Route as Route exposing (Route)
-import Calculations.LeagueTableFromLeagueGames exposing (calculateLeagueTable)
-import Routing exposing (toUrl)
-import GoogleSheet.Api exposing (fetchIndividualSheet)
+import Pages.UpdateHelpers exposing (showRouteRequiringIndividualSheetApi)
 
 individualSheetRequest : String -> Model -> ( Model, Cmd Msg )
 individualSheetRequest leagueTitle model  =
-    ( { model | 
-            leagueTable = RemoteData.Loading
-            , route = Route.LeagueTableRoute leagueTitle 
-      }
-    , fetchLeagueGames leagueTitle model.config )
-
-individualSheetResponse : Model -> WebData LeagueGames -> String -> ( Model, Cmd Msg )
-individualSheetResponse  model response leagueTitle =
-    ( 
-        { model | leagueTable = RemoteData.map calculateLeagueTable response }
-        , newUrl <| toUrl <| model.route
-    )
-
-fetchLeagueGames : String -> Config -> Cmd Msg
-fetchLeagueGames leagueTitle config =
-    fetchIndividualSheet 
-        leagueTitle
-        config 
-        (IndividualSheetResponse leagueTitle)
+    showRouteRequiringIndividualSheetApi 
+        leagueTitle 
+        (Route.LeagueTableRoute leagueTitle)
+        model 

--- a/src/Pages/LeagueTable/Update.elm
+++ b/src/Pages/LeagueTable/Update.elm
@@ -1,13 +1,20 @@
-module Pages.LeagueTable.Update exposing (individualSheetRequest)
+module Pages.LeagueTable.Update exposing (showLeagueTable, refreshLeagueTable)
 
 import Msg exposing (..)
 import Models.Model exposing (Model)
 import Models.Route as Route exposing (Route)
-import Pages.UpdateHelpers exposing (showRouteRequiringIndividualSheetApi)
+import Pages.UpdateHelpers exposing (showRouteRequiringIndividualSheetApi, refreshRouteRequiringIndividualSheetApi)
 
-individualSheetRequest : String -> Model -> ( Model, Cmd Msg )
-individualSheetRequest leagueTitle model  =
+showLeagueTable : String -> Model -> ( Model, Cmd Msg )
+showLeagueTable leagueTitle model  =
     showRouteRequiringIndividualSheetApi 
+        leagueTitle 
+        (Route.LeagueTableRoute leagueTitle)
+        model 
+
+refreshLeagueTable : String -> Model -> ( Model, Cmd Msg )
+refreshLeagueTable leagueTitle model  =
+    refreshRouteRequiringIndividualSheetApi 
         leagueTitle 
         (Route.LeagueTableRoute leagueTitle)
         model 

--- a/src/Pages/LeagueTable/Update.elm
+++ b/src/Pages/LeagueTable/Update.elm
@@ -9,12 +9,12 @@ showLeagueTable : String -> Model -> ( Model, Cmd Msg )
 showLeagueTable leagueTitle model  =
     showRouteRequiringIndividualSheetApi 
         leagueTitle 
-        (Route.LeagueTableRoute leagueTitle)
+        (Route.LeagueTable leagueTitle)
         model 
 
 refreshLeagueTable : String -> Model -> ( Model, Cmd Msg )
 refreshLeagueTable leagueTitle model  =
     refreshRouteRequiringIndividualSheetApi 
         leagueTitle 
-        (Route.LeagueTableRoute leagueTitle)
+        (Route.LeagueTable leagueTitle)
         model 

--- a/src/Pages/LeagueTable/View.elm
+++ b/src/Pages/LeagueTable/View.elm
@@ -23,9 +23,9 @@ page leagueTitle response responsive =
         ( SingleHeader <| 
             HeaderBar 
                 [ BackHeaderButton ShowLeagueList
-                , ResultsFixturesHeaderButton <| IndividualSheetRequestForResultsFixtures leagueTitle ] 
+                , ResultsFixturesHeaderButton <| ShowResultsFixtures leagueTitle ] 
                 (Maybe.withDefault "" (decodeUri leagueTitle))
-                [ RefreshHeaderButton <| IndividualSheetRequest leagueTitle ] )
+                [ RefreshHeaderButton <| RefreshLeagueTable leagueTitle ] )
         ( maybeResponse response (leagueTableElement responsive) )
 
 

--- a/src/Pages/LeagueTable/View.elm
+++ b/src/Pages/LeagueTable/View.elm
@@ -22,7 +22,7 @@ page leagueTitle response responsive =
     Page
         ( SingleHeader <| 
             HeaderBar 
-                [ BackHeaderButton AllSheetSummaryRequest
+                [ BackHeaderButton ShowLeagueList
                 , ResultsFixturesHeaderButton <| IndividualSheetRequestForResultsFixtures leagueTitle ] 
                 (Maybe.withDefault "" (decodeUri leagueTitle))
                 [ RefreshHeaderButton <| IndividualSheetRequest leagueTitle ] )

--- a/src/Pages/RenderPage.elm
+++ b/src/Pages/RenderPage.elm
@@ -112,7 +112,7 @@ title titleText =
 
 backIcon : Element style variation msg
 backIcon =
-    Html.span [ Html.Attributes.class "fas fa-arrow-alt-circle-left" ] []
+    Html.span [ Html.Attributes.class "data-test-back fas fa-arrow-alt-circle-left" ] []
         |> Element.html
 
 refreshIcon : Element style variation msg

--- a/src/Pages/ResultsFixtures/Update.elm
+++ b/src/Pages/ResultsFixtures/Update.elm
@@ -9,12 +9,12 @@ showResultsFixtures : String -> Model -> ( Model, Cmd Msg )
 showResultsFixtures leagueTitle model  =
     showRouteRequiringIndividualSheetApi 
         leagueTitle 
-        (Route.ResultsFixturesRoute leagueTitle)
+        (Route.ResultsFixtures leagueTitle)
         model 
 
 refreshResultsFixtures : String -> Model -> ( Model, Cmd Msg )
 refreshResultsFixtures leagueTitle model  =
     refreshRouteRequiringIndividualSheetApi 
         leagueTitle 
-        (Route.ResultsFixturesRoute leagueTitle)
+        (Route.ResultsFixtures leagueTitle)
         model 

--- a/src/Pages/ResultsFixtures/Update.elm
+++ b/src/Pages/ResultsFixtures/Update.elm
@@ -1,13 +1,20 @@
-module Pages.ResultsFixtures.Update exposing (individualSheetRequestForResultsFixtures)
+module Pages.ResultsFixtures.Update exposing (showResultsFixtures, refreshResultsFixtures)
 
 import Msg exposing (..)
 import Models.Model exposing (Model)
 import Models.Route as Route exposing (Route)
-import Pages.UpdateHelpers exposing (showRouteRequiringIndividualSheetApi)
+import Pages.UpdateHelpers exposing (showRouteRequiringIndividualSheetApi, refreshRouteRequiringIndividualSheetApi)
 
-individualSheetRequestForResultsFixtures : String -> Model -> ( Model, Cmd Msg )
-individualSheetRequestForResultsFixtures leagueTitle model  =
+showResultsFixtures : String -> Model -> ( Model, Cmd Msg )
+showResultsFixtures leagueTitle model  =
     showRouteRequiringIndividualSheetApi 
+        leagueTitle 
+        (Route.ResultsFixturesRoute leagueTitle)
+        model 
+
+refreshResultsFixtures : String -> Model -> ( Model, Cmd Msg )
+refreshResultsFixtures leagueTitle model  =
+    refreshRouteRequiringIndividualSheetApi 
         leagueTitle 
         (Route.ResultsFixturesRoute leagueTitle)
         model 

--- a/src/Pages/ResultsFixtures/Update.elm
+++ b/src/Pages/ResultsFixtures/Update.elm
@@ -1,40 +1,13 @@
-module Pages.ResultsFixtures.Update exposing (individualSheetRequestForResultsFixtures, individualSheetResponseForResultsFixtures)
-
-import Navigation exposing (newUrl)
-import RemoteData exposing (WebData)
+module Pages.ResultsFixtures.Update exposing (individualSheetRequestForResultsFixtures)
 
 import Msg exposing (..)
 import Models.Model exposing (Model)
-import Models.LeagueGames exposing (LeagueGames)
-import Models.Config exposing (Config)
 import Models.Route as Route exposing (Route)
-import Routing exposing (toUrl)
-import GoogleSheet.Api exposing (fetchIndividualSheet)
-import Calculations.ResultsFixturesFromLeagueGames exposing (calculateResultsFixtures)
+import Pages.UpdateHelpers exposing (showRouteRequiringIndividualSheetApi)
 
 individualSheetRequestForResultsFixtures : String -> Model -> ( Model, Cmd Msg )
 individualSheetRequestForResultsFixtures leagueTitle model  =
-    ( { model | 
-            leagueGames = RemoteData.Loading
-            , resultsFixtures = RemoteData.Loading
-            , route = Route.ResultsFixturesRoute leagueTitle
-       }
-       , fetchLeagueGames leagueTitle model.config )
-
-individualSheetResponseForResultsFixtures : Model -> WebData LeagueGames -> String -> ( Model, Cmd Msg )
-individualSheetResponseForResultsFixtures  model response leagueTitle =
-    -- probably define a new shared function that takes the model and returns the newUrl with the route in the model
-    -- this will reduce duplication and make it impossible to mismatch the change in urls
-    ( 
-        { model | 
-            leagueGames = response
-            , resultsFixtures = RemoteData.map calculateResultsFixtures response }
-        , newUrl <| toUrl <| model.route
-    )
-
-fetchLeagueGames : String -> Config -> Cmd Msg
-fetchLeagueGames leagueTitle config =
-    fetchIndividualSheet 
+    showRouteRequiringIndividualSheetApi 
         leagueTitle 
-        config 
-        (IndividualSheetResponseForResultsFixtures leagueTitle)
+        (Route.ResultsFixturesRoute leagueTitle)
+        model 

--- a/src/Pages/ResultsFixtures/View.elm
+++ b/src/Pages/ResultsFixtures/View.elm
@@ -30,9 +30,9 @@ page leagueTitle response progessive =
 headerBar: String -> HeaderBar
 headerBar leagueTitle = 
     HeaderBar 
-        [ BackHeaderButton <| IndividualSheetRequest leagueTitle ] 
+        [ BackHeaderButton <| ShowLeagueTable leagueTitle ] 
         (Maybe.withDefault "" <| decodeUri leagueTitle)
-        [ RefreshHeaderButton <| IndividualSheetRequestForResultsFixtures leagueTitle ]
+        [ RefreshHeaderButton <| RefreshResultsFixtures leagueTitle ]
 
 fixturesResultsElement : Responsive -> ResultsFixtures -> Element Styles variation Msg
 fixturesResultsElement responsive resultsFixtures =

--- a/src/Pages/UpdateHelpers.elm
+++ b/src/Pages/UpdateHelpers.elm
@@ -21,7 +21,7 @@ import Models.Route as Route exposing (Route)
 showRouteRequiringIndividualSheetApi : String -> Route -> Model -> ( Model, Cmd Msg )
 showRouteRequiringIndividualSheetApi leagueTitle route model =
     if (Dict.member leagueTitle model.leagueTables == False
-        || Dict.member leagueTitle model.resultsFixturess == False)
+        || Dict.member leagueTitle model.resultsFixtures == False)
     then  
         refreshRouteRequiringIndividualSheetApi leagueTitle route model
     else 
@@ -32,7 +32,7 @@ refreshRouteRequiringIndividualSheetApi : String -> Route -> Model -> ( Model, C
 refreshRouteRequiringIndividualSheetApi leagueTitle route model =
     ( { model | 
             leagueTables = Dict.insert leagueTitle RemoteData.Loading model.leagueTables
-            , resultsFixturess = Dict.insert leagueTitle RemoteData.Loading model.resultsFixturess
+            , resultsFixtures = Dict.insert leagueTitle RemoteData.Loading model.resultsFixtures
             , route = route 
     }
     , fetchLeagueGames leagueTitle model.config )
@@ -49,7 +49,7 @@ individualSheetResponse  model response leagueTitle =
     ( 
         { model | 
             leagueTables = Dict.insert leagueTitle (RemoteData.map calculateLeagueTable response) model.leagueTables
-            , resultsFixturess = Dict.insert leagueTitle (RemoteData.map calculateResultsFixtures response) model.resultsFixturess
+            , resultsFixtures = Dict.insert leagueTitle (RemoteData.map calculateResultsFixtures response) model.resultsFixtures
         }
         , newUrl <| toUrl <| model.route
     )

--- a/src/Pages/UpdateHelpers.elm
+++ b/src/Pages/UpdateHelpers.elm
@@ -5,7 +5,6 @@ module Pages.UpdateHelpers exposing (
     )
 
 import Dict exposing (Dict)
-import Navigation exposing (newUrl)
 import RemoteData exposing (WebData)
 
 import Models.Model exposing (Model)
@@ -15,7 +14,6 @@ import Msg exposing (..)
 import GoogleSheet.Api exposing (fetchIndividualSheet)
 import Calculations.LeagueTableFromLeagueGames exposing (calculateLeagueTable)
 import Calculations.ResultsFixturesFromLeagueGames exposing (calculateResultsFixtures)
-import Routing exposing (toUrl)
 import Models.Route as Route exposing (Route)
 
 showRouteRequiringIndividualSheetApi : String -> Route -> Model -> ( Model, Cmd Msg )
@@ -51,5 +49,5 @@ individualSheetResponse  model response leagueTitle =
             leagueTables = Dict.insert leagueTitle (RemoteData.map calculateLeagueTable response) model.leagueTables
             , resultsFixtures = Dict.insert leagueTitle (RemoteData.map calculateResultsFixtures response) model.resultsFixtures
         }
-        , newUrl <| toUrl <| model.route
+        , Cmd.none
     )

--- a/src/Pages/UpdateHelpers.elm
+++ b/src/Pages/UpdateHelpers.elm
@@ -1,4 +1,8 @@
-module Pages.UpdateHelpers exposing (individualSheetResponse, showRouteRequiringIndividualSheetApi)
+module Pages.UpdateHelpers exposing (
+    individualSheetResponse
+    , showRouteRequiringIndividualSheetApi
+    , refreshRouteRequiringIndividualSheetApi
+    )
 
 import Dict exposing (Dict)
 import Navigation exposing (newUrl)
@@ -19,15 +23,19 @@ showRouteRequiringIndividualSheetApi leagueTitle route model =
     if (Dict.member leagueTitle model.leagueTables == False
         || Dict.member leagueTitle model.resultsFixturess == False)
     then  
-        ( { model | 
-                leagueTables = Dict.insert leagueTitle RemoteData.Loading model.leagueTables
-                , resultsFixturess = Dict.insert leagueTitle RemoteData.Loading model.resultsFixturess
-                , route = route 
-        }
-        , fetchLeagueGames leagueTitle model.config )
+        refreshRouteRequiringIndividualSheetApi leagueTitle route model
     else 
         ( { model | route = route }, Cmd.none )
 
+
+refreshRouteRequiringIndividualSheetApi : String -> Route -> Model -> ( Model, Cmd Msg )
+refreshRouteRequiringIndividualSheetApi leagueTitle route model =
+    ( { model | 
+            leagueTables = Dict.insert leagueTitle RemoteData.Loading model.leagueTables
+            , resultsFixturess = Dict.insert leagueTitle RemoteData.Loading model.resultsFixturess
+            , route = route 
+    }
+    , fetchLeagueGames leagueTitle model.config )
 
 fetchLeagueGames : String -> Config -> Cmd Msg
 fetchLeagueGames leagueTitle config =

--- a/src/Pages/UpdateHelpers.elm
+++ b/src/Pages/UpdateHelpers.elm
@@ -1,0 +1,42 @@
+module Pages.UpdateHelpers exposing (individualSheetResponse, showRouteRequiringIndividualSheetApi)
+
+import Navigation exposing (newUrl)
+import RemoteData exposing (WebData)
+
+import Models.Model exposing (Model)
+import Models.LeagueGames exposing (LeagueGames)
+import Models.Config exposing (Config)
+import Msg exposing (..)
+import GoogleSheet.Api exposing (fetchIndividualSheet)
+import Calculations.LeagueTableFromLeagueGames exposing (calculateLeagueTable)
+import Calculations.ResultsFixturesFromLeagueGames exposing (calculateResultsFixtures)
+import Routing exposing (toUrl)
+import Models.Route as Route exposing (Route)
+
+showRouteRequiringIndividualSheetApi : String -> Route -> Model -> ( Model, Cmd Msg )
+showRouteRequiringIndividualSheetApi leagueTitle route model =
+    ( { model | 
+            leagueGames = RemoteData.Loading
+            , resultsFixtures = RemoteData.Loading
+            , leagueTable = RemoteData.Loading
+            , route = route 
+      }
+    , fetchLeagueGames leagueTitle model.config )
+
+
+fetchLeagueGames : String -> Config -> Cmd Msg
+fetchLeagueGames leagueTitle config =
+    fetchIndividualSheet 
+        leagueTitle
+        config 
+        (IndividualSheetResponse leagueTitle)
+
+individualSheetResponse : Model -> WebData LeagueGames -> String -> ( Model, Cmd Msg )
+individualSheetResponse  model response leagueTitle =
+    ( 
+        { model | 
+            leagueGames = response
+            , leagueTable = RemoteData.map calculateLeagueTable response
+            , resultsFixtures = RemoteData.map calculateResultsFixtures response }
+        , newUrl <| toUrl <| model.route
+    )

--- a/src/Pages/UpdateHelpers.elm
+++ b/src/Pages/UpdateHelpers.elm
@@ -17,9 +17,8 @@ import Models.Route as Route exposing (Route)
 showRouteRequiringIndividualSheetApi : String -> Route -> Model -> ( Model, Cmd Msg )
 showRouteRequiringIndividualSheetApi leagueTitle route model =
     ( { model | 
-            leagueGames = RemoteData.Loading
-            , resultsFixtures = RemoteData.Loading
-            , leagueTables = Dict.insert leagueTitle RemoteData.Loading model.leagueTables
+            leagueTables = Dict.insert leagueTitle RemoteData.Loading model.leagueTables
+            , resultsFixturess = Dict.insert leagueTitle RemoteData.Loading model.resultsFixturess
             , route = route 
       }
     , fetchLeagueGames leagueTitle model.config )
@@ -36,8 +35,8 @@ individualSheetResponse : Model -> WebData LeagueGames -> String -> ( Model, Cmd
 individualSheetResponse  model response leagueTitle =
     ( 
         { model | 
-            leagueGames = response
-            , leagueTables = Dict.insert leagueTitle (RemoteData.map calculateLeagueTable response) model.leagueTables
-            , resultsFixtures = RemoteData.map calculateResultsFixtures response }
+            leagueTables = Dict.insert leagueTitle (RemoteData.map calculateLeagueTable response) model.leagueTables
+            , resultsFixturess = Dict.insert leagueTitle (RemoteData.map calculateResultsFixtures response) model.resultsFixturess
+        }
         , newUrl <| toUrl <| model.route
     )

--- a/src/Pages/UpdateHelpers.elm
+++ b/src/Pages/UpdateHelpers.elm
@@ -1,5 +1,6 @@
 module Pages.UpdateHelpers exposing (individualSheetResponse, showRouteRequiringIndividualSheetApi)
 
+import Dict exposing (Dict)
 import Navigation exposing (newUrl)
 import RemoteData exposing (WebData)
 
@@ -18,7 +19,7 @@ showRouteRequiringIndividualSheetApi leagueTitle route model =
     ( { model | 
             leagueGames = RemoteData.Loading
             , resultsFixtures = RemoteData.Loading
-            , leagueTable = RemoteData.Loading
+            , leagueTables = Dict.insert leagueTitle RemoteData.Loading model.leagueTables
             , route = route 
       }
     , fetchLeagueGames leagueTitle model.config )
@@ -36,7 +37,7 @@ individualSheetResponse  model response leagueTitle =
     ( 
         { model | 
             leagueGames = response
-            , leagueTable = RemoteData.map calculateLeagueTable response
+            , leagueTables = Dict.insert leagueTitle (RemoteData.map calculateLeagueTable response) model.leagueTables
             , resultsFixtures = RemoteData.map calculateResultsFixtures response }
         , newUrl <| toUrl <| model.route
     )

--- a/src/Pages/UpdateHelpers.elm
+++ b/src/Pages/UpdateHelpers.elm
@@ -16,12 +16,17 @@ import Models.Route as Route exposing (Route)
 
 showRouteRequiringIndividualSheetApi : String -> Route -> Model -> ( Model, Cmd Msg )
 showRouteRequiringIndividualSheetApi leagueTitle route model =
-    ( { model | 
-            leagueTables = Dict.insert leagueTitle RemoteData.Loading model.leagueTables
-            , resultsFixturess = Dict.insert leagueTitle RemoteData.Loading model.resultsFixturess
-            , route = route 
-      }
-    , fetchLeagueGames leagueTitle model.config )
+    if (Dict.member leagueTitle model.leagueTables == False
+        || Dict.member leagueTitle model.resultsFixturess == False)
+    then  
+        ( { model | 
+                leagueTables = Dict.insert leagueTitle RemoteData.Loading model.leagueTables
+                , resultsFixturess = Dict.insert leagueTitle RemoteData.Loading model.resultsFixturess
+                , route = route 
+        }
+        , fetchLeagueGames leagueTitle model.config )
+    else 
+        ( { model | route = route }, Cmd.none )
 
 
 fetchLeagueGames : String -> Config -> Cmd Msg

--- a/src/Routing.elm
+++ b/src/Routing.elm
@@ -12,30 +12,30 @@ parseLocation location =
             route
 
         Nothing ->
-            Route.NotFoundRoute
+            Route.NotFound
 
 -- This doesn't encode the strings, which is a shame, and means that it won't always match what happens in the browser
 toUrl : Route -> String
 toUrl route =
     case route of
-        Route.LeagueListRoute ->
+        Route.LeagueList ->
             "/"
 
-        Route.LeagueTableRoute leagueTitle ->
+        Route.LeagueTable leagueTitle ->
             "/league/" ++ leagueTitle
         
-        Route.ResultsFixturesRoute leagueTitle ->
+        Route.ResultsFixtures leagueTitle ->
             "/results-fixtures/" ++ leagueTitle
         
-        Route.NotFoundRoute ->
+        Route.NotFound ->
             "404"
 
 -- need to test this
 matchers : Parser (Route -> a) a
 matchers =
     oneOf
-        [ map Route.LeagueListRoute top
-        , map Route.LeagueListRoute (s "index.html")
-        , map Route.LeagueTableRoute (s "league" </> string)
-        , map Route.ResultsFixturesRoute (s "results-fixtures" </> string)
+        [ map Route.LeagueList top
+        , map Route.LeagueList (s "index.html")
+        , map Route.LeagueTable (s "league" </> string)
+        , map Route.ResultsFixtures (s "results-fixtures" </> string)
         ]

--- a/src/Routing.elm
+++ b/src/Routing.elm
@@ -14,6 +14,7 @@ parseLocation location =
         Nothing ->
             Route.NotFoundRoute
 
+-- This doesn't encode the strings, which is a shame, and means that it won't always match what happens in the browser
 toUrl : Route -> String
 toUrl route =
     case route of

--- a/src/Routing.elm
+++ b/src/Routing.elm
@@ -1,9 +1,10 @@
 module Routing exposing (parseLocation, toUrl)
 
+import String exposing (split, join)
 import Navigation exposing (Location)
 import Models.Route as Route exposing (Route)
 import UrlParser exposing (..)
-
+import Http
 
 parseLocation : Location -> Route
 parseLocation location =
@@ -14,7 +15,7 @@ parseLocation location =
         Nothing ->
             Route.NotFound
 
--- This doesn't encode the strings, which is a shame, and means that it won't always match what happens in the browser
+
 toUrl : Route -> String
 toUrl route =
     case route of
@@ -22,10 +23,10 @@ toUrl route =
             "/"
 
         Route.LeagueTable leagueTitle ->
-            "/league/" ++ leagueTitle
+            "/league/" ++ Http.encodeUri leagueTitle
         
         Route.ResultsFixtures leagueTitle ->
-            "/results-fixtures/" ++ leagueTitle
+            "/results-fixtures/" ++ Http.encodeUri leagueTitle
         
         Route.NotFound ->
             "404"
@@ -36,6 +37,45 @@ matchers =
     oneOf
         [ map Route.LeagueList top
         , map Route.LeagueList (s "index.html")
-        , map Route.LeagueTable (s "league" </> string)
-        , map Route.ResultsFixtures (s "results-fixtures" </> string)
+        , map Route.LeagueTable (s "league" </> (map urlDecode string))
+        , map Route.ResultsFixtures (s "results-fixtures" </> (map urlDecode string))
         ]
+
+urlDecode: String -> String
+urlDecode encoded = 
+    encoded
+    |> Http.decodeUri
+    |> Maybe.withDefault
+        (partialUrlDecode encoded)
+
+-- Should maybe do this with a List of tuples and a fold, but this is easy to read and fine at the moment.
+-- The list refactor would be worth doing if we have to repeat the replacements somewhere else (say in an
+-- encode function)
+partialUrlDecode: String -> String
+partialUrlDecode encoded = 
+    encoded
+    |> replace "%20" " "
+    |> replace "%21" "!"
+    |> replace "%23" "#"
+    |> replace "%24" "$"
+    |> replace "%26" "&"
+    |> replace "%27" "'"
+    |> replace "%28" "("
+    |> replace "%29" ")"
+    |> replace "%2A" "*"
+    |> replace "%2B" "+"
+    |> replace "%2C" ","
+    |> replace "%2F" "/"
+    |> replace "%3A" ":"
+    |> replace "%3B" ";"
+    |> replace "%3D" "="
+    |> replace "%3F" "?"
+    |> replace "%40" "@"
+    |> replace "%5B" "["
+    |> replace "%5D" "]"
+
+replace: String -> String -> String -> String
+replace toReplace replaceWith source = 
+    String.split toReplace source
+    |> String.join replaceWith
+

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -45,6 +45,7 @@ update msg model =
 
         -- routing
         OnLocationChange location ->
+            -- split this out in to a new function
             -- this relies on the other update cases to actually set the route in the model, probably not the best idea
             let
                 route = parseLocation location
@@ -52,7 +53,7 @@ update msg model =
                 -- If we are already on the page, then don't do anything (otherwise there will be an infinite loop).
                 -- toUrl doesn't encode at the moment, so this can mean that this function executes twice. The first
                 -- time with the unencoded version, then with the version from the browser. This is hard to fix, I 
-                -- think because I am still on elm 0.18 and so can't install the packages that do the encoding.
+                -- think because I am still on elm 0.18 and so can't install the packages that do the encoding. 
                 if ((toUrl route) == (toUrl model.route)) then
                     ( model, Cmd.none )
                 else 

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -5,8 +5,9 @@ import Msg exposing (..)
 import Models.Model exposing (Model)
 import Models.Route as Route exposing (Route)
 import Pages.LeagueList.Update exposing (..)
-import Pages.LeagueTable.Update exposing (individualSheetRequest, individualSheetResponse)
-import Pages.ResultsFixtures.Update exposing (individualSheetRequestForResultsFixtures, individualSheetResponseForResultsFixtures)
+import Pages.LeagueTable.Update exposing (individualSheetRequest)
+import Pages.ResultsFixtures.Update exposing (individualSheetRequestForResultsFixtures)
+import Pages.UpdateHelpers exposing (individualSheetResponse)
 import Routing exposing (..)
 import Navigation exposing (Location)
 
@@ -37,9 +38,6 @@ update msg model =
         IndividualSheetRequestForResultsFixtures leagueTitle ->
             individualSheetRequestForResultsFixtures leagueTitle model
 
-        IndividualSheetResponseForResultsFixtures leagueTitle response ->
-            individualSheetResponseForResultsFixtures model response leagueTitle
-        
         -- responsiveness
         SetScreenSize size ->
             ({ model | device = classifyDevice size }, Cmd.none)

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -49,7 +49,10 @@ update msg model =
             let
                 route = parseLocation location
             in
-                -- If we are already on the page, then don't do anything (otherwise there will be an infinite loop)
+                -- If we are already on the page, then don't do anything (otherwise there will be an infinite loop).
+                -- toUrl doesn't encode at the moment, so this can mean that this function executes twice. The first
+                -- time with the unencoded version, then with the version from the browser. This is hard to fix, I 
+                -- think because I am still on elm 0.18 and so can't install the packages that do the encoding.
                 if ((toUrl route) == (toUrl model.route)) then
                     ( model, Cmd.none )
                 else 

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -5,8 +5,8 @@ import Msg exposing (..)
 import Models.Model exposing (Model)
 import Models.Route as Route exposing (Route)
 import Pages.LeagueList.Update exposing (..)
-import Pages.LeagueTable.Update exposing (individualSheetRequest)
-import Pages.ResultsFixtures.Update exposing (individualSheetRequestForResultsFixtures)
+import Pages.LeagueTable.Update exposing (showLeagueTable, refreshLeagueTable)
+import Pages.ResultsFixtures.Update exposing (showResultsFixtures, refreshResultsFixtures)
 import Pages.UpdateHelpers exposing (individualSheetResponse)
 import Routing exposing (..)
 import Navigation exposing (Location)
@@ -27,17 +27,22 @@ update msg model =
         AllSheetSummaryResponse response ->
             allSheetSummaryResponse model response
 
-        -- League Table
-        IndividualSheetRequest leagueTitle ->
-            individualSheetRequest leagueTitle model
+        -- Fixtures / Results, League Table
+        ShowLeagueTable leagueTitle ->
+            showLeagueTable leagueTitle model
+
+        RefreshLeagueTable leagueTitle ->
+            refreshLeagueTable leagueTitle model
+
+        ShowResultsFixtures leagueTitle ->
+            showResultsFixtures leagueTitle model
+
+        RefreshResultsFixtures leagueTitle ->
+            refreshResultsFixtures leagueTitle model
 
         IndividualSheetResponse leagueTitle response ->
             individualSheetResponse model response leagueTitle
         
-        -- Fixtures / Results
-        IndividualSheetRequestForResultsFixtures leagueTitle ->
-            individualSheetRequestForResultsFixtures leagueTitle model
-
         -- responsiveness
         SetScreenSize size ->
             ({ model | device = classifyDevice size }, Cmd.none)
@@ -62,9 +67,9 @@ updateFromRoute model location route =
         Route.LeagueListRoute ->
             update ShowLeagueList model
         Route.LeagueTableRoute leagueTitle ->
-            update (IndividualSheetRequest leagueTitle) model 
+            update (ShowLeagueTable leagueTitle) model 
         Route.ResultsFixturesRoute leagueTitle ->
-            update (IndividualSheetRequestForResultsFixtures leagueTitle) model 
+            update (ShowResultsFixtures leagueTitle) model 
         Route.NotFoundRoute ->
             let
                 _ = Debug.log "Route not found" location

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -64,13 +64,13 @@ updateFromLocation model location =
 updateFromRoute : Model -> Location -> Route -> ( Model, Cmd Msg )
 updateFromRoute model location route =
     case route of
-        Route.LeagueListRoute ->
+        Route.LeagueList ->
             update ShowLeagueList model
-        Route.LeagueTableRoute leagueTitle ->
+        Route.LeagueTable leagueTitle ->
             update (ShowLeagueTable leagueTitle) model 
-        Route.ResultsFixturesRoute leagueTitle ->
+        Route.ResultsFixtures leagueTitle ->
             update (ShowResultsFixtures leagueTitle) model 
-        Route.NotFoundRoute ->
+        Route.NotFound ->
             let
                 _ = Debug.log "Route not found" location
             in

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -4,7 +4,7 @@ import Element exposing (classifyDevice)
 import Msg exposing (..)
 import Models.Model exposing (Model)
 import Models.Route as Route exposing (Route)
-import Pages.LeagueList.Update exposing (allSheetSummaryRequest, allSheetSummaryResponse)
+import Pages.LeagueList.Update exposing (..)
 import Pages.LeagueTable.Update exposing (individualSheetRequest, individualSheetResponse)
 import Pages.ResultsFixtures.Update exposing (individualSheetRequestForResultsFixtures, individualSheetResponseForResultsFixtures)
 import Routing exposing (..)
@@ -16,8 +16,11 @@ update msg model =
             ( model, Cmd.none )
 
         -- League List
-        AllSheetSummaryRequest ->
-            allSheetSummaryRequest model
+        ShowLeagueList  ->
+            showLeagueList model
+
+        RefreshLeagueList  ->
+            refreshLeagueList model
 
         AllSheetSummaryResponse response ->
             allSheetSummaryResponse model response
@@ -52,7 +55,7 @@ update msg model =
                 else 
                     case route of
                         Route.LeagueListRoute ->
-                            update AllSheetSummaryRequest model
+                            update ShowLeagueList model
                         Route.LeagueTableRoute leagueTitle ->
                             update (IndividualSheetRequest leagueTitle) model 
                         Route.ResultsFixturesRoute leagueTitle ->

--- a/src/View.elm
+++ b/src/View.elm
@@ -1,6 +1,8 @@
 module View exposing (view)
 
+import Dict exposing (Dict)
 import Html exposing (Html)
+import RemoteData exposing (WebData)
 
 import Msg exposing (..)
 import Models.Model exposing ( Model )
@@ -11,6 +13,7 @@ import Pages.ResultsFixtures.View exposing (..)
 import Pages.Page exposing (..)
 import Pages.RenderPage exposing (..)
 import Pages.Responsive exposing (..)
+import Models.LeagueTable exposing (LeagueTable)
 
 
 view : Model -> Html Msg
@@ -18,7 +21,8 @@ view model =
     let
         responsive = calculateResponsive <| toFloat model.device.width
     in
-        renderPage responsive <| page model responsive
+        page model responsive
+        |> renderPage responsive    
 
 page : Model -> Responsive -> Page
 page model responsive =
@@ -26,11 +30,16 @@ page model responsive =
         Route.LeagueListRoute ->
             Pages.LeagueList.View.page model.leagues responsive
         Route.LeagueTableRoute leagueTitle ->
-            Pages.LeagueTable.View.page leagueTitle model.leagueTable responsive
+            Pages.LeagueTable.View.page leagueTitle (getLeagueTable leagueTitle model) responsive
         Route.ResultsFixturesRoute leagueTitle ->
             Pages.ResultsFixtures.View.page leagueTitle model.resultsFixtures responsive
         Route.NotFoundRoute ->
             Pages.LeagueList.View.page model.leagues responsive -- return 404 later
+
+getLeagueTable : String -> Model -> WebData (LeagueTable)
+getLeagueTable leagueTitle model =
+    Dict.get leagueTitle model.leagueTables
+    |> Maybe.withDefault RemoteData.NotAsked
 
 -- notFoundView : Html msg
 -- notFoundView =

--- a/src/View.elm
+++ b/src/View.elm
@@ -44,7 +44,7 @@ getLeagueTable leagueTitle model =
 
 getResultsFixtures : String -> Model -> WebData ResultsFixtures
 getResultsFixtures leagueTitle model =
-    Dict.get leagueTitle model.resultsFixturess
+    Dict.get leagueTitle model.resultsFixtures
     |> Maybe.withDefault RemoteData.NotAsked
 
 -- notFoundView : Html msg

--- a/src/View.elm
+++ b/src/View.elm
@@ -28,13 +28,13 @@ view model =
 page : Model -> Responsive -> Page
 page model responsive =
     case model.route of
-        Route.LeagueListRoute ->
+        Route.LeagueList ->
             Pages.LeagueList.View.page model.leagues responsive
-        Route.LeagueTableRoute leagueTitle ->
+        Route.LeagueTable leagueTitle ->
             Pages.LeagueTable.View.page leagueTitle (getLeagueTable leagueTitle model) responsive
-        Route.ResultsFixturesRoute leagueTitle ->
+        Route.ResultsFixtures leagueTitle ->
             Pages.ResultsFixtures.View.page leagueTitle (getResultsFixtures leagueTitle model) responsive
-        Route.NotFoundRoute ->
+        Route.NotFound ->
             Pages.LeagueList.View.page model.leagues responsive -- return 404 later
 
 getLeagueTable : String -> Model -> WebData LeagueTable

--- a/src/View.elm
+++ b/src/View.elm
@@ -14,6 +14,7 @@ import Pages.Page exposing (..)
 import Pages.RenderPage exposing (..)
 import Pages.Responsive exposing (..)
 import Models.LeagueTable exposing (LeagueTable)
+import Models.ResultsFixtures exposing (ResultsFixtures)
 
 
 view : Model -> Html Msg
@@ -32,13 +33,18 @@ page model responsive =
         Route.LeagueTableRoute leagueTitle ->
             Pages.LeagueTable.View.page leagueTitle (getLeagueTable leagueTitle model) responsive
         Route.ResultsFixturesRoute leagueTitle ->
-            Pages.ResultsFixtures.View.page leagueTitle model.resultsFixtures responsive
+            Pages.ResultsFixtures.View.page leagueTitle (getResultsFixtures leagueTitle model) responsive
         Route.NotFoundRoute ->
             Pages.LeagueList.View.page model.leagues responsive -- return 404 later
 
-getLeagueTable : String -> Model -> WebData (LeagueTable)
+getLeagueTable : String -> Model -> WebData LeagueTable
 getLeagueTable leagueTitle model =
     Dict.get leagueTitle model.leagueTables
+    |> Maybe.withDefault RemoteData.NotAsked
+
+getResultsFixtures : String -> Model -> WebData ResultsFixtures
+getResultsFixtures leagueTitle model =
+    Dict.get leagueTitle model.resultsFixturess
     |> Maybe.withDefault RemoteData.NotAsked
 
 -- notFoundView : Html msg

--- a/tests/DecodeGoogleSheetToGameListTest.elm
+++ b/tests/DecodeGoogleSheetToGameListTest.elm
@@ -7,6 +7,7 @@ import Json.Decode exposing (decodeString)
 import Models.Game exposing (Game)
 import Models.LeagueGames exposing (LeagueGames)
 import GoogleSheet.DecodeGoogleSheetToGameList exposing (decodeSheetToLeagueGames)
+import TestHelpers exposing (..)
 
 -- I could probably fuzz test this by writing a custom fuzzer that created Game 's. 
 -- The values from these could be used to create the json string, and to assert against.
@@ -43,6 +44,14 @@ decodeBlankTeamName =
             blankTeamNameSpreadsheetValuesResponse 
                 |> decodeString (decodeSheetToLeagueGames "Regional Div 1")
                 |> Expect.equal (Ok (LeagueGames "Regional Div 1" [ ])) 
+
+trimWhitespaceFromTeamNames : Test
+trimWhitespaceFromTeamNames =
+    test "Trims whitespace from team names" <|
+        \() ->
+            teamNamesWithWhitespaceSpreadsheetValuesResponse 
+                |> decodeString (decodeSheetToLeagueGames "Regional Div 1")
+                |> Expect.equal (Ok (LeagueGames "Regional Div 1" [ { vanillaGame | homeTeamName = "Castle", awayTeamName = "Meridian"} ]))
 
 isError : Result error value -> Bool
 isError result =
@@ -101,6 +110,18 @@ blankTeamNameSpreadsheetValuesResponse =
       "1",
       "3",
       ""
+    ]
+    """
+
+teamNamesWithWhitespaceSpreadsheetValuesResponse : String
+teamNamesWithWhitespaceSpreadsheetValuesResponse =
+  createSpreadsheetValuesResponse
+    """
+    [
+      "Castle ",
+      "",
+      "",
+      " Meridian"
     ]
     """
 

--- a/tests/DecodeGoogleSheetToGameListTest.elm
+++ b/tests/DecodeGoogleSheetToGameListTest.elm
@@ -4,10 +4,9 @@ import Test exposing (..)
 import Date exposing (..)
 import Expect
 import Json.Decode exposing (decodeString)
-import Models.Game exposing (Game)
+import Models.Game exposing (Game, vanillaGame)
 import Models.LeagueGames exposing (LeagueGames)
 import GoogleSheet.DecodeGoogleSheetToGameList exposing (decodeSheetToLeagueGames)
-import TestHelpers exposing (..)
 
 -- I could probably fuzz test this by writing a custom fuzzer that created Game 's. 
 -- The values from these could be used to create the json string, and to assert against.

--- a/tests/LeagueListUpdateTest.elm
+++ b/tests/LeagueListUpdateTest.elm
@@ -23,6 +23,21 @@ apiError =
                 |> getModel
                 |> Expect.equal { vanillaModel | leagues = response }
 
+-- this doesn't completely test that the api call gets make, but it would be strange code
+-- that set leagues to RemoteData.Loading without also calling the Api
+callsApi : Test
+callsApi =
+    test "Calls the APi if the results arent already available in the model" <|
+        \() ->
+            update 
+                ShowLeagueList 
+                vanillaModel
+            |> getModel
+            |> Expect.equal 
+                { vanillaModel | 
+                    leagues = RemoteData.Loading
+                    , route = Route.LeagueListRoute }
+
 cachesAPiResult : Test
 cachesAPiResult =
     test "Only calls the api if the results isn't already available in the model" <|

--- a/tests/LeagueListUpdateTest.elm
+++ b/tests/LeagueListUpdateTest.elm
@@ -10,6 +10,7 @@ import Update exposing (update)
 import Msg exposing (..)
 import Models.Model exposing (Model, vanillaModel)
 import Models.LeagueSummary exposing (LeagueSummary)
+import Models.Route as Route exposing (Route)
 
 apiError : Test
 apiError =
@@ -21,6 +22,21 @@ apiError =
                 update (AllSheetSummaryResponse response) vanillaModel
                 |> getModel
                 |> Expect.equal { vanillaModel | leagues = response }
+
+cachesAPiResult : Test
+cachesAPiResult =
+    test "Only calls the api if the results isn't already available in the model" <|
+        \() ->
+            let 
+                model = 
+                    { vanillaModel | 
+                        leagues = RemoteData.Success []
+                        , route = Route.LeagueListRoute }
+            in 
+                update 
+                    ShowLeagueList 
+                    model
+                |> Expect.equal ( model, Cmd.none )
 
 apiSuccess : Test
 apiSuccess =

--- a/tests/LeagueListUpdateTest.elm
+++ b/tests/LeagueListUpdateTest.elm
@@ -38,8 +38,8 @@ callsApi =
                     leagues = RemoteData.Loading
                     , route = Route.LeagueListRoute }
 
-cachesAPiResult : Test
-cachesAPiResult =
+cachesApiResult : Test
+cachesApiResult =
     test "Only calls the api if the results isn't already available in the model" <|
         \() ->
             let 
@@ -52,6 +52,24 @@ cachesAPiResult =
                     ShowLeagueList 
                     model
                 |> Expect.equal ( model, Cmd.none )
+
+
+refreshesAPi : Test
+refreshesAPi =
+    test "Calls the APi if asked to, even if the data already exists" <|
+        \() ->
+            let 
+                model = 
+                    { vanillaModel | 
+                        leagues = RemoteData.Success []
+                        , route = Route.LeagueListRoute }
+            in 
+                update 
+                    RefreshLeagueList 
+                    model
+                |> getModel
+                |> Expect.equal { model | leagues = RemoteData.Loading }
+
 
 apiSuccess : Test
 apiSuccess =

--- a/tests/LeagueListUpdateTest.elm
+++ b/tests/LeagueListUpdateTest.elm
@@ -36,7 +36,7 @@ callsApi =
             |> Expect.equal 
                 { vanillaModel | 
                     leagues = RemoteData.Loading
-                    , route = Route.LeagueListRoute }
+                    , route = Route.LeagueList }
 
 cachesApiResult : Test
 cachesApiResult =
@@ -46,7 +46,7 @@ cachesApiResult =
                 model = 
                     { vanillaModel | 
                         leagues = RemoteData.Success []
-                        , route = Route.LeagueListRoute }
+                        , route = Route.LeagueList }
             in 
                 update 
                     ShowLeagueList 
@@ -62,7 +62,7 @@ refreshesAPi =
                 model = 
                     { vanillaModel | 
                         leagues = RemoteData.Success []
-                        , route = Route.LeagueListRoute }
+                        , route = Route.LeagueList }
             in 
                 update 
                     RefreshLeagueList 

--- a/tests/LeagueTableUpdateTest.elm
+++ b/tests/LeagueTableUpdateTest.elm
@@ -41,7 +41,7 @@ callsApi =
             |> Expect.equal 
                 { vanillaModel | 
                     leagueTables = Dict.singleton leagueTitle RemoteData.Loading
-                    , resultsFixturess = Dict.singleton leagueTitle RemoteData.Loading
+                    , resultsFixtures = Dict.singleton leagueTitle RemoteData.Loading
                     , route = Route.LeagueTableRoute leagueTitle }
 
 cachesApiResult : Test
@@ -52,7 +52,7 @@ cachesApiResult =
                 model = 
                     { vanillaModel | 
                         leagueTables = Dict.singleton leagueTitle (RemoteData.Success vanillaLeagueTable)
-                        , resultsFixturess = Dict.singleton leagueTitle (RemoteData.Success vanillaResultsFixtures)
+                        , resultsFixtures = Dict.singleton leagueTitle (RemoteData.Success vanillaResultsFixtures)
                     }
             in 
                 update 
@@ -69,7 +69,7 @@ refreshesApi =
                 model = 
                     { vanillaModel | 
                         leagueTables = Dict.singleton leagueTitle (RemoteData.Success vanillaLeagueTable)
-                        , resultsFixturess = Dict.singleton leagueTitle (RemoteData.Success vanillaResultsFixtures)
+                        , resultsFixtures = Dict.singleton leagueTitle (RemoteData.Success vanillaResultsFixtures)
                     }
             in 
                 update 
@@ -79,7 +79,7 @@ refreshesApi =
                 |> Expect.equal 
                     { model | 
                         leagueTables = Dict.singleton leagueTitle RemoteData.Loading
-                        , resultsFixturess = Dict.singleton leagueTitle RemoteData.Loading
+                        , resultsFixtures = Dict.singleton leagueTitle RemoteData.Loading
                         , route = Route.LeagueTableRoute leagueTitle }
 
 

--- a/tests/LeagueTableUpdateTest.elm
+++ b/tests/LeagueTableUpdateTest.elm
@@ -58,7 +58,8 @@ cachesApiResult =
                 update 
                     (ShowLeagueTable leagueTitle)
                     model
-                |> Expect.equal ( { model | route = Route.LeagueTable leagueTitle }, Cmd.none )
+                |> getModel
+                |> Expect.equal { model | route = Route.LeagueTable leagueTitle }
 
 
 refreshesApi : Test

--- a/tests/LeagueTableUpdateTest.elm
+++ b/tests/LeagueTableUpdateTest.elm
@@ -35,7 +35,7 @@ callsApi =
     test "Calls the APi if the results arent already available in the model" <|
         \() ->
             update 
-                (IndividualSheetRequest leagueTitle)
+                (ShowLeagueTable leagueTitle)
                 vanillaModel
             |> getModel
             |> Expect.equal 
@@ -44,8 +44,8 @@ callsApi =
                     , resultsFixturess = Dict.singleton leagueTitle RemoteData.Loading
                     , route = Route.LeagueTableRoute leagueTitle }
 
-cachesAPiResult : Test
-cachesAPiResult =
+cachesApiResult : Test
+cachesApiResult =
     test "Only calls the api if the results isn't already available in the model" <|
         \() ->
             let 
@@ -53,12 +53,35 @@ cachesAPiResult =
                     { vanillaModel | 
                         leagueTables = Dict.singleton leagueTitle (RemoteData.Success vanillaLeagueTable)
                         , resultsFixturess = Dict.singleton leagueTitle (RemoteData.Success vanillaResultsFixtures)
-                        , route = Route.LeagueTableRoute leagueTitle }
+                    }
             in 
                 update 
-                    (IndividualSheetRequest leagueTitle)
+                    (ShowLeagueTable leagueTitle)
                     model
-                |> Expect.equal ( model, Cmd.none )
+                |> Expect.equal ( { model | route = Route.LeagueTableRoute leagueTitle }, Cmd.none )
+
+
+refreshesApi : Test
+refreshesApi =
+    test "Calls the APi if asked to, even if the data already exists" <|
+        \() ->
+            let 
+                model = 
+                    { vanillaModel | 
+                        leagueTables = Dict.singleton leagueTitle (RemoteData.Success vanillaLeagueTable)
+                        , resultsFixturess = Dict.singleton leagueTitle (RemoteData.Success vanillaResultsFixtures)
+                    }
+            in 
+                update 
+                    (RefreshLeagueTable leagueTitle)
+                    model
+                |> getModel
+                |> Expect.equal 
+                    { model | 
+                        leagueTables = Dict.singleton leagueTitle RemoteData.Loading
+                        , resultsFixturess = Dict.singleton leagueTitle RemoteData.Loading
+                        , route = Route.LeagueTableRoute leagueTitle }
+
 
 leagueTitle : String                
 leagueTitle =

--- a/tests/LeagueTableUpdateTest.elm
+++ b/tests/LeagueTableUpdateTest.elm
@@ -42,7 +42,7 @@ callsApi =
                 { vanillaModel | 
                     leagueTables = Dict.singleton leagueTitle RemoteData.Loading
                     , resultsFixtures = Dict.singleton leagueTitle RemoteData.Loading
-                    , route = Route.LeagueTableRoute leagueTitle }
+                    , route = Route.LeagueTable leagueTitle }
 
 cachesApiResult : Test
 cachesApiResult =
@@ -58,7 +58,7 @@ cachesApiResult =
                 update 
                     (ShowLeagueTable leagueTitle)
                     model
-                |> Expect.equal ( { model | route = Route.LeagueTableRoute leagueTitle }, Cmd.none )
+                |> Expect.equal ( { model | route = Route.LeagueTable leagueTitle }, Cmd.none )
 
 
 refreshesApi : Test
@@ -80,7 +80,7 @@ refreshesApi =
                     { model | 
                         leagueTables = Dict.singleton leagueTitle RemoteData.Loading
                         , resultsFixtures = Dict.singleton leagueTitle RemoteData.Loading
-                        , route = Route.LeagueTableRoute leagueTitle }
+                        , route = Route.LeagueTable leagueTitle }
 
 
 leagueTitle : String                

--- a/tests/LeagueTableUpdateTest.elm
+++ b/tests/LeagueTableUpdateTest.elm
@@ -9,8 +9,10 @@ import Msg exposing (..)
 import Models.Model exposing (Model, vanillaModel)
 import Models.Game exposing (Game, vanillaGame)
 import Models.LeagueGames exposing (LeagueGames)
-import Models.LeagueTable exposing (LeagueTable)
+import Models.LeagueTable exposing (..)
+import Models.ResultsFixtures exposing (..)
 import Calculations.LeagueTableFromLeagueGames exposing (calculateLeagueTable)
+import Models.Route as Route exposing (Route)
 
 apiSuccess : Test
 apiSuccess = 
@@ -25,6 +27,38 @@ apiSuccess =
                     leagueTitle
                     (calculatedLeagueTableRemoteData game)
                 )
+
+-- this doesn't completely test that the api call gets make, but it would be strange code
+-- that set leagues to RemoteData.Loading without also calling the Api
+callsApi : Test
+callsApi =
+    test "Calls the APi if the results arent already available in the model" <|
+        \() ->
+            update 
+                (IndividualSheetRequest leagueTitle)
+                vanillaModel
+            |> getModel
+            |> Expect.equal 
+                { vanillaModel | 
+                    leagueTables = Dict.singleton leagueTitle RemoteData.Loading
+                    , resultsFixturess = Dict.singleton leagueTitle RemoteData.Loading
+                    , route = Route.LeagueTableRoute leagueTitle }
+
+cachesAPiResult : Test
+cachesAPiResult =
+    test "Only calls the api if the results isn't already available in the model" <|
+        \() ->
+            let 
+                model = 
+                    { vanillaModel | 
+                        leagueTables = Dict.singleton leagueTitle (RemoteData.Success vanillaLeagueTable)
+                        , resultsFixturess = Dict.singleton leagueTitle (RemoteData.Success vanillaResultsFixtures)
+                        , route = Route.LeagueTableRoute leagueTitle }
+            in 
+                update 
+                    (IndividualSheetRequest leagueTitle)
+                    model
+                |> Expect.equal ( model, Cmd.none )
 
 leagueTitle : String                
 leagueTitle =
@@ -57,3 +91,6 @@ calculatedLeagueTableRemoteData game =
             (LeagueGames leagueTitle [ game ])
         ) 
     
+getModel : (Model, Cmd Msg) -> Model
+getModel (model, cmd) = 
+    model

--- a/tests/ResultsFixturesHelpers.elm
+++ b/tests/ResultsFixturesHelpers.elm
@@ -17,10 +17,6 @@ expectFirstDay: (Maybe LeagueGamesForDay -> Expectation) -> ResultsFixtures -> E
 expectFirstDay expect resultsFixtures =
     expect (List.head resultsFixtures.days)
 
-vanillaGame : Game
-vanillaGame = 
-    Game "" Nothing "" Nothing Nothing "" "" "" "" "" 
-
 unscheduledGame: Game
 unscheduledGame = 
     Game "" Nothing "" Nothing Nothing "" "" "" "" ""

--- a/tests/ResultsFixturesUpdateTest.elm
+++ b/tests/ResultsFixturesUpdateTest.elm
@@ -10,7 +10,10 @@ import Msg exposing (..)
 import Models.Model exposing (Model, vanillaModel)
 import Models.Game exposing (vanillaGame)
 import Models.LeagueGames exposing (LeagueGames)
+import Models.LeagueTable exposing (..)
+import Models.ResultsFixtures exposing (..)
 import Calculations.ResultsFixturesFromLeagueGames exposing (calculateResultsFixtures)
+import Models.Route as Route exposing (Route)
 
 oneGame : Test
 oneGame =
@@ -24,6 +27,38 @@ oneGame =
                     (RemoteData.Success <| calculateResultsFixtures leagueGames)
                 )                
 
+-- this doesn't completely test that the api call gets make, but it would be strange code
+-- that set leagues to RemoteData.Loading without also calling the Api
+callsApi : Test
+callsApi =
+    test "Calls the APi if the results arent already available in the model" <|
+        \() ->
+            update 
+                (IndividualSheetRequestForResultsFixtures leagueTitle)
+                vanillaModel
+            |> getModel
+            |> Expect.equal 
+                { vanillaModel | 
+                    leagueTables = Dict.singleton leagueTitle RemoteData.Loading
+                    , resultsFixturess = Dict.singleton leagueTitle RemoteData.Loading
+                    , route = Route.ResultsFixturesRoute leagueTitle }
+
+cachesAPiResult : Test
+cachesAPiResult =
+    test "Only calls the api if the results isn't already available in the model" <|
+        \() ->
+            let 
+                model = 
+                    { vanillaModel | 
+                        leagueTables = Dict.singleton leagueTitle (RemoteData.Success vanillaLeagueTable)
+                        , resultsFixturess = Dict.singleton leagueTitle (RemoteData.Success vanillaResultsFixtures)
+                        , route = Route.ResultsFixturesRoute leagueTitle }
+            in 
+                update 
+                    (IndividualSheetRequestForResultsFixtures leagueTitle)
+                    model
+                |> Expect.equal ( model, Cmd.none )
+
 leagueTitle : String                
 leagueTitle =
     "Regional Div 1"
@@ -31,3 +66,7 @@ leagueTitle =
 leagueGames: LeagueGames
 leagueGames = 
      LeagueGames leagueTitle [ vanillaGame ]
+
+getModel : (Model, Cmd Msg) -> Model
+getModel (model, cmd) = 
+    model

--- a/tests/ResultsFixturesUpdateTest.elm
+++ b/tests/ResultsFixturesUpdateTest.elm
@@ -7,9 +7,9 @@ import RemoteData exposing (WebData)
 import Update exposing (update)
 import Msg exposing (..)
 import Models.Model exposing (Model, vanillaModel)
+import Models.Game exposing (vanillaGame)
 import Models.LeagueGames exposing (LeagueGames)
 import Models.ResultsFixtures exposing (ResultsFixtures)
-import TestHelpers exposing (..)
 import Calculations.ResultsFixturesFromLeagueGames exposing (calculateResultsFixtures)
 
 oneGame : Test

--- a/tests/ResultsFixturesUpdateTest.elm
+++ b/tests/ResultsFixturesUpdateTest.elm
@@ -34,7 +34,7 @@ callsApi =
     test "Calls the APi if the results arent already available in the model" <|
         \() ->
             update 
-                (IndividualSheetRequestForResultsFixtures leagueTitle)
+                (ShowResultsFixtures leagueTitle)
                 vanillaModel
             |> getModel
             |> Expect.equal 
@@ -52,12 +52,33 @@ cachesAPiResult =
                     { vanillaModel | 
                         leagueTables = Dict.singleton leagueTitle (RemoteData.Success vanillaLeagueTable)
                         , resultsFixturess = Dict.singleton leagueTitle (RemoteData.Success vanillaResultsFixtures)
-                        , route = Route.ResultsFixturesRoute leagueTitle }
+                    }
             in 
                 update 
-                    (IndividualSheetRequestForResultsFixtures leagueTitle)
+                    (ShowResultsFixtures leagueTitle)
                     model
-                |> Expect.equal ( model, Cmd.none )
+                |> Expect.equal ( { model | route = Route.ResultsFixturesRoute leagueTitle }, Cmd.none )
+
+refreshesApi : Test
+refreshesApi =
+    test "Calls the APi if asked to, even if the data already exists" <|
+        \() ->
+            let 
+                model = 
+                    { vanillaModel | 
+                        leagueTables = Dict.singleton leagueTitle (RemoteData.Success vanillaLeagueTable)
+                        , resultsFixturess = Dict.singleton leagueTitle (RemoteData.Success vanillaResultsFixtures)
+                    }
+            in 
+                update 
+                    (RefreshResultsFixtures leagueTitle)
+                    model
+                |> getModel
+                |> Expect.equal 
+                    { model | 
+                        leagueTables = Dict.singleton leagueTitle RemoteData.Loading
+                        , resultsFixturess = Dict.singleton leagueTitle RemoteData.Loading
+                        , route = Route.ResultsFixturesRoute leagueTitle }
 
 leagueTitle : String                
 leagueTitle =

--- a/tests/ResultsFixturesUpdateTest.elm
+++ b/tests/ResultsFixturesUpdateTest.elm
@@ -57,7 +57,8 @@ cachesAPiResult =
                 update 
                     (ShowResultsFixtures leagueTitle)
                     model
-                |> Expect.equal ( { model | route = Route.ResultsFixtures leagueTitle }, Cmd.none )
+                |> getModel
+                |> Expect.equal { model | route = Route.ResultsFixtures leagueTitle }
 
 refreshesApi : Test
 refreshesApi =

--- a/tests/ResultsFixturesUpdateTest.elm
+++ b/tests/ResultsFixturesUpdateTest.elm
@@ -20,7 +20,7 @@ oneGame =
     test "Calculates results / fixtures on success and adds to league table dictionary" <|
         \() ->
             update (IndividualSheetResponse leagueTitle <| RemoteData.Success leagueGames) vanillaModel
-            |> \(model, msg) -> model.resultsFixturess
+            |> \(model, msg) -> model.resultsFixtures
             |> Expect.equal
                 (Dict.singleton 
                     leagueTitle
@@ -40,7 +40,7 @@ callsApi =
             |> Expect.equal 
                 { vanillaModel | 
                     leagueTables = Dict.singleton leagueTitle RemoteData.Loading
-                    , resultsFixturess = Dict.singleton leagueTitle RemoteData.Loading
+                    , resultsFixtures = Dict.singleton leagueTitle RemoteData.Loading
                     , route = Route.ResultsFixturesRoute leagueTitle }
 
 cachesAPiResult : Test
@@ -51,7 +51,7 @@ cachesAPiResult =
                 model = 
                     { vanillaModel | 
                         leagueTables = Dict.singleton leagueTitle (RemoteData.Success vanillaLeagueTable)
-                        , resultsFixturess = Dict.singleton leagueTitle (RemoteData.Success vanillaResultsFixtures)
+                        , resultsFixtures = Dict.singleton leagueTitle (RemoteData.Success vanillaResultsFixtures)
                     }
             in 
                 update 
@@ -67,7 +67,7 @@ refreshesApi =
                 model = 
                     { vanillaModel | 
                         leagueTables = Dict.singleton leagueTitle (RemoteData.Success vanillaLeagueTable)
-                        , resultsFixturess = Dict.singleton leagueTitle (RemoteData.Success vanillaResultsFixtures)
+                        , resultsFixtures = Dict.singleton leagueTitle (RemoteData.Success vanillaResultsFixtures)
                     }
             in 
                 update 
@@ -77,7 +77,7 @@ refreshesApi =
                 |> Expect.equal 
                     { model | 
                         leagueTables = Dict.singleton leagueTitle RemoteData.Loading
-                        , resultsFixturess = Dict.singleton leagueTitle RemoteData.Loading
+                        , resultsFixtures = Dict.singleton leagueTitle RemoteData.Loading
                         , route = Route.ResultsFixturesRoute leagueTitle }
 
 leagueTitle : String                

--- a/tests/ResultsFixturesUpdateTest.elm
+++ b/tests/ResultsFixturesUpdateTest.elm
@@ -7,10 +7,9 @@ import RemoteData exposing (WebData)
 import Update exposing (update)
 import Msg exposing (..)
 import Models.Model exposing (Model, vanillaModel)
-import Models.Game exposing (Game)
 import Models.LeagueGames exposing (LeagueGames)
 import Models.ResultsFixtures exposing (ResultsFixtures)
-import ResultsFixturesHelpers exposing (..)
+import TestHelpers exposing (..)
 import Calculations.ResultsFixturesFromLeagueGames exposing (calculateResultsFixtures)
 
 oneGame : Test
@@ -27,7 +26,7 @@ oneGame =
 
 anyLeagueGames: WebData LeagueGames
 anyLeagueGames = 
-    RemoteData.Success ( LeagueGames "Div 1" [ game ] )
+    RemoteData.Success ( LeagueGames "Div 1" [ vanillaGame ] )
 
 expectLeagueGames: WebData LeagueGames -> Model -> Expectation
 expectLeagueGames expectedLeagueGames model =
@@ -36,7 +35,3 @@ expectLeagueGames expectedLeagueGames model =
 expectResultsFixtures: WebData ResultsFixtures -> Model -> Expectation
 expectResultsFixtures expectedResultsFixtures model =
     Expect.equal expectedResultsFixtures model.resultsFixtures
-
-game: Game
-game = 
-    vanillaGame

--- a/tests/ResultsFixturesUpdateTest.elm
+++ b/tests/ResultsFixturesUpdateTest.elm
@@ -16,7 +16,7 @@ oneGame : Test
 oneGame =
     test "setLeagueGames" <|
         \() ->
-            update (IndividualSheetResponseForResultsFixtures "" anyLeagueGames) vanillaModel
+            update (IndividualSheetResponse "" anyLeagueGames) vanillaModel
             |> \(model, msg) -> model
             |> Expect.all 
                 [ expectLeagueGames anyLeagueGames

--- a/tests/ResultsFixturesUpdateTest.elm
+++ b/tests/ResultsFixturesUpdateTest.elm
@@ -1,5 +1,6 @@
 module ResultsFixturesUpdateTest exposing (..)
 
+import Dict exposing (Dict)
 import Test exposing (..)
 import Expect
 import Expect exposing (Expectation)
@@ -9,29 +10,24 @@ import Msg exposing (..)
 import Models.Model exposing (Model, vanillaModel)
 import Models.Game exposing (vanillaGame)
 import Models.LeagueGames exposing (LeagueGames)
-import Models.ResultsFixtures exposing (ResultsFixtures)
 import Calculations.ResultsFixturesFromLeagueGames exposing (calculateResultsFixtures)
 
 oneGame : Test
 oneGame =
-    test "setLeagueGames" <|
+    test "Calculates results / fixtures on success and adds to league table dictionary" <|
         \() ->
-            update (IndividualSheetResponse "" anyLeagueGames) vanillaModel
-            |> \(model, msg) -> model
-            |> Expect.all 
-                [ expectLeagueGames anyLeagueGames
-                , expectResultsFixtures <| RemoteData.map calculateResultsFixtures anyLeagueGames
-                ]
+            update (IndividualSheetResponse leagueTitle <| RemoteData.Success leagueGames) vanillaModel
+            |> \(model, msg) -> model.resultsFixturess
+            |> Expect.equal
+                (Dict.singleton 
+                    leagueTitle
+                    (RemoteData.Success <| calculateResultsFixtures leagueGames)
+                )                
 
+leagueTitle : String                
+leagueTitle =
+    "Regional Div 1"
 
-anyLeagueGames: WebData LeagueGames
-anyLeagueGames = 
-    RemoteData.Success ( LeagueGames "Div 1" [ vanillaGame ] )
-
-expectLeagueGames: WebData LeagueGames -> Model -> Expectation
-expectLeagueGames expectedLeagueGames model =
-    Expect.equal expectedLeagueGames model.leagueGames
-
-expectResultsFixtures: WebData ResultsFixtures -> Model -> Expectation
-expectResultsFixtures expectedResultsFixtures model =
-    Expect.equal expectedResultsFixtures model.resultsFixtures
+leagueGames: LeagueGames
+leagueGames = 
+     LeagueGames leagueTitle [ vanillaGame ]

--- a/tests/ResultsFixturesUpdateTest.elm
+++ b/tests/ResultsFixturesUpdateTest.elm
@@ -41,7 +41,7 @@ callsApi =
                 { vanillaModel | 
                     leagueTables = Dict.singleton leagueTitle RemoteData.Loading
                     , resultsFixtures = Dict.singleton leagueTitle RemoteData.Loading
-                    , route = Route.ResultsFixturesRoute leagueTitle }
+                    , route = Route.ResultsFixtures leagueTitle }
 
 cachesAPiResult : Test
 cachesAPiResult =
@@ -57,7 +57,7 @@ cachesAPiResult =
                 update 
                     (ShowResultsFixtures leagueTitle)
                     model
-                |> Expect.equal ( { model | route = Route.ResultsFixturesRoute leagueTitle }, Cmd.none )
+                |> Expect.equal ( { model | route = Route.ResultsFixtures leagueTitle }, Cmd.none )
 
 refreshesApi : Test
 refreshesApi =
@@ -78,7 +78,7 @@ refreshesApi =
                     { model | 
                         leagueTables = Dict.singleton leagueTitle RemoteData.Loading
                         , resultsFixtures = Dict.singleton leagueTitle RemoteData.Loading
-                        , route = Route.ResultsFixturesRoute leagueTitle }
+                        , route = Route.ResultsFixtures leagueTitle }
 
 leagueTitle : String                
 leagueTitle =

--- a/tests/ResultsFixturesViewForPlayedGameTest.elm
+++ b/tests/ResultsFixturesViewForPlayedGameTest.elm
@@ -8,8 +8,7 @@ import Date.Extra exposing (..)
 
 import Msg exposing (..)
 import ResultsFixturesViewHelpers exposing (..)
-import ResultsFixturesHelpers exposing (..)
-
+import TestHelpers exposing (..)
 
 onePlayedGame : Test
 onePlayedGame =

--- a/tests/ResultsFixturesViewForPlayedGameTest.elm
+++ b/tests/ResultsFixturesViewForPlayedGameTest.elm
@@ -8,7 +8,7 @@ import Date.Extra exposing (..)
 
 import Msg exposing (..)
 import ResultsFixturesViewHelpers exposing (..)
-import TestHelpers exposing (..)
+import Models.Game exposing (vanillaGame)
 
 onePlayedGame : Test
 onePlayedGame =

--- a/tests/ResultsFixturesViewForUnplayedGameTest.elm
+++ b/tests/ResultsFixturesViewForUnplayedGameTest.elm
@@ -8,7 +8,7 @@ import Date.Extra exposing (..)
 
 import Msg exposing (..)
 import ResultsFixturesViewHelpers exposing (..)
-import ResultsFixturesHelpers exposing (..)
+import TestHelpers exposing (..)
 
 
 oneUnplayedGame : Test

--- a/tests/ResultsFixturesViewForUnplayedGameTest.elm
+++ b/tests/ResultsFixturesViewForUnplayedGameTest.elm
@@ -8,7 +8,7 @@ import Date.Extra exposing (..)
 
 import Msg exposing (..)
 import ResultsFixturesViewHelpers exposing (..)
-import TestHelpers exposing (..)
+import Models.Game exposing (vanillaGame)
 
 
 oneUnplayedGame : Test

--- a/tests/ResultsFixturesViewForUnplayedGameWithNoDateTest.elm
+++ b/tests/ResultsFixturesViewForUnplayedGameWithNoDateTest.elm
@@ -6,7 +6,7 @@ import Test.Html.Selector exposing (text, class)
 
 import Msg exposing (..)
 import ResultsFixturesViewHelpers exposing (..)
-import TestHelpers exposing (..)
+import Models.Game exposing (vanillaGame)
 
 
 oneUnplayedGame : Test

--- a/tests/ResultsFixturesViewForUnplayedGameWithNoDateTest.elm
+++ b/tests/ResultsFixturesViewForUnplayedGameWithNoDateTest.elm
@@ -6,7 +6,7 @@ import Test.Html.Selector exposing (text, class)
 
 import Msg exposing (..)
 import ResultsFixturesViewHelpers exposing (..)
-import ResultsFixturesHelpers exposing (..)
+import TestHelpers exposing (..)
 
 
 oneUnplayedGame : Test

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -1,0 +1,7 @@
+module TestHelpers exposing (..)
+
+import Models.Game exposing (Game)
+
+vanillaGame : Game
+vanillaGame = 
+    Game "" Nothing "" Nothing Nothing "" "" "" "" "" 

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -1,7 +1,0 @@
-module TestHelpers exposing (..)
-
-import Models.Game exposing (Game)
-
-vanillaGame : Game
-vanillaGame = 
-    Game "" Nothing "" Nothing Nothing "" "" "" "" "" 


### PR DESCRIPTION
The code used to call the google sheets api every time you wanted to look at a page, but it now stores things in the model, and will only call the api if the data doesn't already exist, or if you click refresh.

There were two problems with the browser navigation.

One was that the league titles from the sheet weren't being encoded,
so they looked different when I set them in the browser, and when the
browser returned them. This is fixed by encoding / decoding.

The other was that when the browser notified us of a location change,
we added the new location to the history, which doesn't make sense, as
it is already in the history. this led to strange results, mostly
having to click back twice to actually do anything.