### PR TITLE
Fix minor layout bugs

### DIFF
--- a/src/Pages/LeagueTable/View.elm
+++ b/src/Pages/LeagueTable/View.elm
@@ -78,7 +78,7 @@ teamRow tableColumns styles aTeam =
     rowWithStyle
         styles.leagueTableTeamRow
         [ styles.mediumPadding
-        , styles.mediumSpacing
+        , styles.smallSpacing
         , dataTestClass "team" ]
         (List.map (teamCell aTeam) tableColumns)
 

--- a/src/Pages/ResultsFixtures/View.elm
+++ b/src/Pages/ResultsFixtures/View.elm
@@ -90,7 +90,9 @@ gameRow styles game =
         , width fill
         ]
         [ column
-            [ teamWidth ]
+            [ teamWidth
+            , alignTop 
+            ]
             [ paragraph
                 [ Font.alignRight, dataTestClass "homeTeamName" ]
                 [ text game.homeTeamName ]
@@ -100,11 +102,14 @@ gameRow styles game =
                 , dataTestClass "homeTeamGoals" ]
                 [ text game.homeTeamGoals ]
             ]
-        , row
+        , rowWithStyle
             styles.resultFixtureScore
+            [ alignTop ]
             (scoreSlashTime game styles)
         , column
-            [ teamWidth ]
+            [ teamWidth
+            , alignTop 
+            ]
             [ paragraph
                 [ alignLeft
                 , dataTestClass "awayTeamName" ]


### PR DESCRIPTION
The header row wasn't properly aligned with the content rows in the league table, and the team names and the scores weren't aligned in the results if there were differeng rows of scorers for each team